### PR TITLE
[기능요청][CICD] GitHub Action을 사용한 자동 CI/CD 워크플로우 추가 : feat(CICD-init): appleboy/ssh-action 버전 변경

### DIFF
--- a/.github/workflows/TICKET-MATE-BE-CICD.yaml
+++ b/.github/workflows/TICKET-MATE-BE-CICD.yaml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Deploy
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}


### PR DESCRIPTION
## ✨ 변경 사항
--- 
Deploy 스크립스 실행시 

ssh: handshake failed: ssh: unable to authenticate, attempted methods [none], no supported methods remain 에러가 나는 문제

로컬 터미널에서는 접속이 잘 됨, sshd_config 내부 PasswordAuthentication 설정또한 문제없음, 깃허브 환경변수 또한 문제 없음

문제를 찾아본 결과 버전관련 이슈 확인 

해결방안 : 버전을 master로 변경

레퍼런스 : https://github.com/appleboy/ssh-action/issues/297

## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
