### PR TITLE
[기능요청][CICD] GitHub Action을 사용한 자동 CI/CD 워크플로우 추가 : feat(CICD-init): 포트변경 및 디렉토리 경로 변경 #3

### DIFF
--- a/.github/workflows/TICKET-MATE-BE-CICD.yaml
+++ b/.github/workflows/TICKET-MATE-BE-CICD.yaml
@@ -105,7 +105,7 @@ jobs:
               -e TZ=Asia/Seoul \
               -e "SPRING_PROFILES_ACTIVE=prod" \
               -v /etc/localtime:/etc/localtime:ro \
-              -v /volume1/projects/ticket-mate:/mnt/ticket-mate \
+              -v /home/ticketmate98/Desktop/projects/ticket-mate/
               ${{ secrets.DOCKERHUB_USERNAME }}/ticket-mate-back:${BRANCH}
 
             echo "배포가 성공적으로 완료되었습니다."

--- a/.github/workflows/TICKET-MATE-BE-CICD.yaml
+++ b/.github/workflows/TICKET-MATE-BE-CICD.yaml
@@ -66,7 +66,7 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           password: ${{ secrets.SERVER_PASSWORD }}
-          port: 22
+          port: 2022
           script: |
             set -e
             


### PR DESCRIPTION
## ✨ 변경 사항
--- 

`port: 2022` 로 재변경

컨테이너 바인딩 경로 `-v /home/ticketmate98/Desktop/projects/ticket-mate/` 변경


## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
