### PR TITLE
[기능요청][CICD] GitHub Action을 사용한 자동 CI/CD 워크플로우 추가 : feat(CICD-init): 태그네임에 / 포함 안되도록 변경 #3 

### DIFF
--- a/.github/workflows/TICKET-MATE-BE-CICD.yaml
+++ b/.github/workflows/TICKET-MATE-BE-CICD.yaml
@@ -52,7 +52,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/ticket-mate-back:${{ github.ref_name }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/ticket-mate-back:${{ github.ref_name replace('/', '-') }}
           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/ticket-mate-back:cache
           cache-to: type=inline
 


### PR DESCRIPTION
## ✨ 변경 사항
--- 
Pull Request가 refs/pull/15/merge 형태로 잡히면, github.ref_name이 15/merge가 되어버려서 태그가 ...:15/merge 형태가 됨 

하지만 Docker 이미지 태그에는 슬래시 문자가 들어갈 수 없음.

해결 : `${{ github.ref_name }}` -> ${{` github.ref_name replace('/', '-') }}` 로 변경


## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
