### PR TITLE
[기능추가][로그인/회원가입] 로그인/회원가입 로직 init feat: 로그인 기본경로 "/login" -> "/api/auth/sign-in"수정 및 공연장 정보 저장 api 관리자 controller 분리 #53 #30

### DIFF
--- a/src/main/java/com/ticketmate/backend/controller/AdminController.java
+++ b/src/main/java/com/ticketmate/backend/controller/AdminController.java
@@ -1,13 +1,12 @@
 package com.ticketmate.backend.controller;
 
-import com.ticketmate.backend.object.dto.ConcertHallFilteredRequest;
-import com.ticketmate.backend.object.dto.ConcertHallFilteredResponse;
+import com.ticketmate.backend.object.dto.ConcertHallInfoRequest;
 import com.ticketmate.backend.object.dto.CustomUserDetails;
 import com.ticketmate.backend.service.ConcertHallService;
 import com.ticketmate.backend.util.log.LogMonitoringInvocation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,21 +16,23 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/concert-hall")
+@RequestMapping("/admin")
 @Tag(
-        name = "공연장 관련 API",
-        description = "공연장 관련 API 제공"
+        name = "관리자 API",
+        description = "관리자 페이지 관련 API 제공"
 )
-public class ConcertHallController implements ConcertHallControllerDocs{
+public class AdminController implements AdminControllerDocs{
 
     private final ConcertHallService concertHallService;
 
     @Override
-    @PostMapping(value = "/filtered")
+    @PostMapping(value = "/concert-hall/save")
     @LogMonitoringInvocation
-    public ResponseEntity<Page<ConcertHallFilteredResponse>> filteredConcertHall(
+    public ResponseEntity<Void> saveHallInfo(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @RequestBody ConcertHallFilteredRequest request) {
-        return ResponseEntity.ok(concertHallService.filteredConcertHall(request));
+            @Valid @RequestBody ConcertHallInfoRequest request) {
+        request.setMember(customUserDetails.getMember());
+        concertHallService.saveHallInfo(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/ticketmate/backend/controller/AdminControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/AdminControllerDocs.java
@@ -1,0 +1,31 @@
+package com.ticketmate.backend.controller;
+
+import com.ticketmate.backend.object.dto.ConcertHallInfoRequest;
+import com.ticketmate.backend.object.dto.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+
+public interface AdminControllerDocs {
+
+    @Operation(
+            summary = "공연장 정보 저장",
+            description = """
+                                        
+                    이 API는 관리자 인증이 필요합니다
+
+                    ### 요청 파라미터
+                    - **concertHallName** (String): 공연장 명 (중복 불가)
+                    - **capacity** (Integer): 수용인원
+                    - **address** (String): 공연장 주소
+                    - **concertHallUrl** (String): 공연장 웹사이트 URL
+                                
+                    ### 유의사항
+                    - `concertHallName`은 고유해야 합니다.
+                    - `concertHallUrl`은 'http://' 또는 'https://' 로 시작하는 문자열이어야 합니다
+
+                    """
+    )
+    ResponseEntity<Void> saveHallInfo(
+            CustomUserDetails customUserDetails,
+            ConcertHallInfoRequest request);
+}

--- a/src/main/java/com/ticketmate/backend/controller/AuthController.java
+++ b/src/main/java/com/ticketmate/backend/controller/AuthController.java
@@ -11,10 +11,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/auth")
 @Tag(
         name = "인증 관련 API",
         description = "회원 인증 관련 API 제공"
@@ -24,7 +26,7 @@ public class AuthController implements AuthControllerDocs {
     private final MemberService memberService;
 
     @Override
-    @PostMapping(value = "/api/auth/signup")
+    @PostMapping(value = "/sign-up")
     @LogMonitoringInvocation
     public ResponseEntity<Void> signUp(
             @Valid @RequestBody SignUpRequest request) {
@@ -33,7 +35,7 @@ public class AuthController implements AuthControllerDocs {
     }
 
     @Override
-    @PostMapping(value = "/login", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/sign-in", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @LogMonitoringInvocation
     public ResponseEntity<Void> signIn(SignInRequest request) {
         return ResponseEntity.ok().build();

--- a/src/main/java/com/ticketmate/backend/controller/ConcertHallControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/ConcertHallControllerDocs.java
@@ -7,27 +7,7 @@ import org.springframework.http.ResponseEntity;
 
 public interface ConcertHallControllerDocs {
 
-    @Operation(
-            summary = "공연장 정보 저장",
-            description = """
-                                        
-                    이 API는 관리자 인증이 필요합니다
 
-                    ### 요청 파라미터
-                    - **concertHallName** (String): 공연장 명 (중복 불가)
-                    - **capacity** (Integer): 수용인원
-                    - **address** (String): 공연장 주소
-                    - **concertHallUrl** (String): 공연장 웹사이트 URL
-                                
-                    ### 유의사항
-                    - `concertHallName`은 고유해야 합니다.
-                    - `concertHallUrl`은 'http://' 또는 'https://' 로 시작하는 문자열이어야 합니다
-
-                    """
-    )
-    ResponseEntity<Void> saveHallInfo(
-            CustomUserDetails customUserDetails,
-            ConcertHallInfoRequest request);
 
     @Operation(
             summary = "공연장 정보 필터링",

--- a/src/main/java/com/ticketmate/backend/util/config/SecurityConfig.java
+++ b/src/main/java/com/ticketmate/backend/util/config/SecurityConfig.java
@@ -52,6 +52,13 @@ public class SecurityConfig {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        LoginFilter loginFilter = new LoginFilter(jwtUtil,
+                authenticationManager(authenticationConfiguration),
+                redisTemplate,
+                memberRepository);
+        loginFilter.setFilterProcessesUrl("/api/auth/sign-in");
+
         return http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
@@ -76,12 +83,7 @@ public class SecurityConfig {
                         new TokenAuthenticationFilter(jwtUtil, customUserDetailsService),
                         UsernamePasswordAuthenticationFilter.class
                 )
-                .addFilterAt(
-                        new LoginFilter(jwtUtil,
-                                authenticationManager(authenticationConfiguration),
-                                redisTemplate,
-                                memberRepository),
-                        UsernamePasswordAuthenticationFilter.class
+                .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class
                 )
                 .build();
     }

--- a/src/main/java/com/ticketmate/backend/util/config/SecurityUrls.java
+++ b/src/main/java/com/ticketmate/backend/util/config/SecurityUrls.java
@@ -13,7 +13,8 @@ public class SecurityUrls {
      */
     public static final List<String> AUTH_WHITELIST = Arrays.asList(
             // API
-            "/api/auth/signup", // 회원가입
+            "/api/auth/sign-up", // 회원가입
+            "/api/auth/sign-in", // 로그인
 
 
             // Swagger


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
