### PR TITLE
🔧 [기능요청][대리인 신청] 대리인 권한 신청 및 대리인 포트폴리오 업로드 #76

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,8 @@ dependencies {
     // MapStruct 어노테이션 프로세서
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
+    //S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ticketmate/backend/controller/portfolio/PortfolioController.java
+++ b/src/main/java/com/ticketmate/backend/controller/portfolio/PortfolioController.java
@@ -1,0 +1,40 @@
+package com.ticketmate.backend.controller.portfolio;
+
+import com.ticketmate.backend.controller.portfolio.docs.PortfolioControllerDocs;
+import com.ticketmate.backend.object.dto.auth.request.CustomUserDetails;
+import com.ticketmate.backend.object.dto.portfolio.request.PortfolioRequest;
+import com.ticketmate.backend.object.postgres.Member.Member;
+import com.ticketmate.backend.service.portfolio.PortfolioService;
+import com.ticketmate.backend.util.log.LogMonitoringInvocation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/portfolio")
+@Tag(
+        name = "포트폴리오 API",
+        description = "포트폴리오 관련 API 제공"
+)
+public class PortfolioController implements PortfolioControllerDocs {
+    private final PortfolioService portfolioService;
+    @Override
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @LogMonitoringInvocation
+    public ResponseEntity<UUID> uploadPortfolio(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @ModelAttribute PortfolioRequest request) {
+        Member member = customUserDetails.getMember();
+        return ResponseEntity.ok(portfolioService.uploadPortfolio(request, member));
+    }
+}

--- a/src/main/java/com/ticketmate/backend/controller/portfolio/docs/PortfolioControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/portfolio/docs/PortfolioControllerDocs.java
@@ -1,0 +1,31 @@
+package com.ticketmate.backend.controller.portfolio.docs;
+
+import com.ticketmate.backend.object.dto.auth.request.CustomUserDetails;
+import com.ticketmate.backend.object.dto.portfolio.request.PortfolioRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+public interface PortfolioControllerDocs {
+    @Operation(
+            summary = "의뢰자 -> 대리자로 변경하기 위한 포트폴리오 업로드",
+            description = """
+                                        
+                    이 API는 인증이 필요합니다.
+
+                    ### 요청 파라미터
+                    - **publicRelations** (String): 자기소개 [필수]
+                    - **portfolioImg** (MultipartFile): 포트폴리오 이미지 [필수]
+                    
+                                                   
+                    ### 유의사항
+                    - 이미지가 공백 혹은 첨부가 안되어있으면 에러가 발생합니다.
+                    - 포트폴리오 검증을 받기위해 이미지를 첨부할 시 이미지는 최대20개 첨부 가능합니다.
+                    - 파일의 확장자는 jpg, jpeg, png, JPG, JPEG, PNG 만 가능합니다.
+                    """
+    )
+    ResponseEntity<UUID> uploadPortfolio(
+            CustomUserDetails customUserDetails,
+            PortfolioRequest request);
+}

--- a/src/main/java/com/ticketmate/backend/object/constants/PortfolioType.java
+++ b/src/main/java/com/ticketmate/backend/object/constants/PortfolioType.java
@@ -1,0 +1,13 @@
+package com.ticketmate.backend.object.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PortfolioType {
+    UNDER_REVIEW("포트폴리오 검토중"),  // 현재 관리자가 검토중인 포트폴리오
+    REVIEW_COMPLETED("승인된 포트폴리오"),  // 관리자가 승인해 의뢰인 -> 대리인으로 바뀐 포트폴리오
+    COMPANION("반려된 포트폴리오");  // 관리자에게 반려당한 포트폴리오
+    private final String description;
+    }

--- a/src/main/java/com/ticketmate/backend/object/constants/PortfolioType.java
+++ b/src/main/java/com/ticketmate/backend/object/constants/PortfolioType.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum PortfolioType {
-    UNDER_REVIEW("포트폴리오 검토중"),  // 현재 관리자가 검토중인 포트폴리오
+    UNDER_REVIEW("포트폴리오 검토 대기중"),  // 관리자가 아직 보지않은 포트폴리오 (최초 업로드시 모두 해당상태로 저장됩니다.)
+
+    REVIEWING("포트폴리오 검토중"),  // 현재 관리자가 검토중인 포트폴리오
     REVIEW_COMPLETED("승인된 포트폴리오"),  // 관리자가 승인해 의뢰인 -> 대리인으로 바뀐 포트폴리오
     COMPANION("반려된 포트폴리오");  // 관리자에게 반려당한 포트폴리오
     private final String description;
-    }
+}

--- a/src/main/java/com/ticketmate/backend/object/dto/portfolio/request/PortfolioRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/portfolio/request/PortfolioRequest.java
@@ -19,5 +19,5 @@ public class PortfolioRequest {
     @Schema(defaultValue = "NCT드림, 세븐틴, 투바투, 보넥도등 남자 아이돌 티켓팅 전문입니다. 최대한 고객님의 니즈에 맞춰 자리 잡아드립니다.")
     private String publicRelations;
 
-    private List<MultipartFile> portfolioImg;
+    private List<MultipartFile> portfolioImgs;
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/portfolio/request/PortfolioRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/portfolio/request/PortfolioRequest.java
@@ -17,7 +17,7 @@ public class PortfolioRequest {
     @NotBlank(message = "자기소개를 입력하세요")
     @Size(min = 20, max = 200, message = "자기소개는 20자 이상, 200자 이하로 입력해 주세요.")
     @Schema(defaultValue = "NCT드림, 세븐틴, 투바투, 보넥도등 남자 아이돌 티켓팅 전문입니다. 최대한 고객님의 니즈에 맞춰 자리 잡아드립니다.")
-    private String publicRelations;
+    private String portfolioDescription;
 
     private List<MultipartFile> portfolioImgs;
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/portfolio/request/PortfolioRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/portfolio/request/PortfolioRequest.java
@@ -1,0 +1,23 @@
+package com.ticketmate.backend.object.dto.portfolio.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@ToString
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class PortfolioRequest {
+    @NotBlank(message = "자기소개를 입력하세요")
+    @Size(min = 20, max = 200, message = "자기소개는 20자 이상, 200자 이하로 입력해 주세요.")
+    @Schema(defaultValue = "NCT드림, 세븐틴, 투바투, 보넥도등 남자 아이돌 티켓팅 전문입니다. 최대한 고객님의 니즈에 맞춰 자리 잡아드립니다.")
+    private String publicRelations;
+
+    private List<MultipartFile> portfolioImg;
+}

--- a/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
@@ -26,7 +26,7 @@ public class Portfolio extends BasePostgresEntity {
     @Column(columnDefinition = "uuid DEFAULT uuid_generate_v4()", updatable = false, nullable = false)
     private UUID portfolioId;
 
-    private String publicRelations;  // 자기소개
+    private String portfolioDescription;  // 자기소개
 
     @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<PortfolioImg> imgList = new ArrayList<>();

--- a/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
@@ -1,0 +1,40 @@
+package com.ticketmate.backend.object.postgres.portfolio;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ticketmate.backend.object.postgres.Member.Member;
+import com.ticketmate.backend.object.postgres.global.BasePostgresEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(callSuper = true)
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class Portfolio extends BasePostgresEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(columnDefinition = "uuid DEFAULT uuid_generate_v4()", updatable = false, nullable = false)
+    private UUID portfolioId;
+
+    private String publicRelations;  // 자기소개
+
+    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<PortfolioImg> imgList = new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    public void addImg(PortfolioImg img) {
+        this.getImgList().add(img);
+        img.setPortfolio(this);
+    }
+}

--- a/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
@@ -1,6 +1,7 @@
 package com.ticketmate.backend.object.postgres.portfolio;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ticketmate.backend.object.constants.PortfolioType;
 import com.ticketmate.backend.object.postgres.Member.Member;
 import com.ticketmate.backend.object.postgres.global.BasePostgresEntity;
 import jakarta.persistence.*;
@@ -32,6 +33,9 @@ public class Portfolio extends BasePostgresEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private PortfolioType portfolioType;
 
     public void addImg(PortfolioImg img) {
         this.getImgList().add(img);

--- a/src/main/java/com/ticketmate/backend/object/postgres/portfolio/PortfolioImg.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/portfolio/PortfolioImg.java
@@ -1,0 +1,31 @@
+package com.ticketmate.backend.object.postgres.portfolio;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ticketmate.backend.object.postgres.global.BasePostgresEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(callSuper = true)
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class PortfolioImg extends BasePostgresEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(columnDefinition = "uuid DEFAULT uuid_generate_v4()", updatable = false, nullable = false)
+    private UUID portfolioImgId;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String imgName;  // 포트폴리오 이미지 URL
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Portfolio portfolio;
+}

--- a/src/main/java/com/ticketmate/backend/repository/postgres/portfolio/PortfolioRepository.java
+++ b/src/main/java/com/ticketmate/backend/repository/postgres/portfolio/PortfolioRepository.java
@@ -1,0 +1,9 @@
+package com.ticketmate.backend.repository.postgres.portfolio;
+
+import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PortfolioRepository extends JpaRepository<Portfolio, UUID> {
+}

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -5,7 +5,6 @@ import com.ticketmate.backend.object.dto.portfolio.request.PortfolioRequest;
 import com.ticketmate.backend.object.postgres.Member.Member;
 import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
 import com.ticketmate.backend.object.postgres.portfolio.PortfolioImg;
-import com.ticketmate.backend.repository.postgres.portfolio.PortfolioImgRepository;
 import com.ticketmate.backend.repository.postgres.portfolio.PortfolioRepository;
 import com.ticketmate.backend.service.s3.S3Service;
 import com.ticketmate.backend.util.exception.CustomException;
@@ -25,7 +24,6 @@ import java.util.UUID;
 @Slf4j
 public class PortfolioService {
     private final PortfolioRepository portfolioRepository;
-    private final PortfolioImgRepository portfolioImgRepository;
     private final S3Service s3Service;
     private static final Integer MAX_IMAGE_COUNT = 20;
 
@@ -62,7 +60,6 @@ public class PortfolioService {
                 portfolioImgList.add(portfolioImg);
                 portfolio.addImg(portfolioImg);
             }
-            portfolioImgRepository.saveAll(portfolioImgList);
 
             log.debug("총 저장된 이미지 파일 갯수 : {}", portfolioImgList.size());
         }

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -70,7 +70,7 @@ public class PortfolioService {
 
         portfolioRepository.save(portfolio);
 
-        log.info("총 저장된 파일 갯수 : {}", portfolio.getImgList().size());
+        log.debug("총 저장된 파일 갯수 : {}", portfolio.getImgList().size());
 
         return portfolio.getPortfolioId();
     }
@@ -87,7 +87,7 @@ public class PortfolioService {
 
         // 중복이 되지 않는 고유한 파일이름 생성
         String randomFilename = generateRandomFilename(originalFilename);
-        log.info("filename: {}", randomFilename);
+        log.debug("filename: {}", randomFilename);
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(portfolioImg.getSize());
@@ -101,17 +101,17 @@ public class PortfolioService {
         }
 
         String s3UrlString = amazonS3.getUrl(bucket, randomFilename).toString();
-        log.info("S3URL: {}", s3UrlString);
+        log.debug("S3URL: {}", s3UrlString);
         String cloudFrontUrl = domain + randomFilename;
 
-        log.info("ImgURL: {}", cloudFrontUrl);
+        log.debug("ImgURL: {}", cloudFrontUrl);
 
         PortfolioImg img = PortfolioImg.builder()
                 .imgName(randomFilename)
                 .portfolio(portfolio)
                 .build();
 
-        log.info("Img : {}", img.getImgName());
+        log.debug("Img : {}", img.getImgName());
         return randomFilename;
     }
 

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -3,6 +3,7 @@ package com.ticketmate.backend.service.portfolio;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.ticketmate.backend.object.constants.PortfolioType;
 import com.ticketmate.backend.object.dto.portfolio.request.PortfolioRequest;
 import com.ticketmate.backend.object.postgres.Member.Member;
 import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
@@ -52,6 +53,7 @@ public class PortfolioService {
         Portfolio portfolio = Portfolio.builder()
                 .member(member)
                 .publicRelations(request.getPublicRelations())
+                .portfolioType(PortfolioType.UNDER_REVIEW)
                 .build();
 
         /**

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -42,10 +42,6 @@ public class PortfolioService {
      */
     @Transactional
     public UUID uploadPortfolio(PortfolioRequest request, Member member){
-
-        if (request.getPortfolioImg() == null || request.getPortfolioImg().isEmpty()) {
-            throw new CustomException(ErrorCode.PORTFOLIO_IMG_BLACK);
-        }
         if (request.getPortfolioImg().size() > MAX_IMAGE) {
             throw new CustomException(ErrorCode.PORTFOLIO_IMG_MAX_SIZE);
         }
@@ -59,15 +55,17 @@ public class PortfolioService {
         /**
          * Cascade 옵션을 활용해서 부모 엔티티만 Save 해서 update 쿼리 최소화
          */
-        for (MultipartFile imgFile : request.getPortfolioImg()) {
-            String fileName = s3Upload(imgFile, portfolio);
+        if (request.getPortfolioImg().size() > 0) {
+            for (MultipartFile imgFile : request.getPortfolioImg()) {
+                String fileName = s3Upload(imgFile, portfolio);
 
-            PortfolioImg portfolioImg = PortfolioImg.builder()
-                    .imgName(fileName)
-                    .portfolio(portfolio)
-                    .build();
+                PortfolioImg portfolioImg = PortfolioImg.builder()
+                        .imgName(fileName)
+                        .portfolio(portfolio)
+                        .build();
 
-            portfolio.addImg(portfolioImg);
+                portfolio.addImg(portfolioImg);
+            }
         }
 
         portfolioRepository.save(portfolio);

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -32,7 +32,7 @@ public class PortfolioService {
     private String bucket;
     @Value("${cloud.aws.s3.path.portfolio.cloud-front-domain}")
     private String domain;
-    private static final Integer MAX_IMAGE = 20;
+    private static final Integer MAX_IMAGE_COUNT = 20;
 
     /**
      * 포트폴리오 업로드
@@ -42,7 +42,7 @@ public class PortfolioService {
      */
     @Transactional
     public UUID uploadPortfolio(PortfolioRequest request, Member member){
-        if (request.getPortfolioImg().size() > MAX_IMAGE) {
+        if (request.getPortfolioImg().size() > MAX_IMAGE_COUNT) {
             throw new CustomException(ErrorCode.PORTFOLIO_IMG_MAX_SIZE);
         }
 

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 public class PortfolioService {
     private final PortfolioRepository portfolioRepository;
     private final S3Service s3Service;
-    private static final Integer MAX_IMAGE_COUNT = 20;
+    private static final Integer MAX_IMG_COUNT = 20;
 
     /**
      * 포트폴리오 업로드
@@ -35,7 +35,7 @@ public class PortfolioService {
      */
     @Transactional
     public UUID uploadPortfolio(PortfolioRequest request, Member member){
-        if (request.getPortfolioImgs().size() > MAX_IMAGE_COUNT) {
+        if (request.getPortfolioImgs().size() > MAX_IMG_COUNT) {
             throw new CustomException(ErrorCode.PORTFOLIO_IMG_MAX_COUNT_EXCEEDED);
         }
 
@@ -50,7 +50,7 @@ public class PortfolioService {
         if (request.getPortfolioImgs().size() > 0) {
             List<PortfolioImg> portfolioImgList = new ArrayList<>();
             for (MultipartFile imgFile : request.getPortfolioImgs()) {
-                String fileName = uploadPortfolioImage(imgFile, portfolio);
+                String fileName = uploadPortfolioImg(imgFile, portfolio);
 
                 PortfolioImg portfolioImg = PortfolioImg.builder()
                         .imgName(fileName)
@@ -68,7 +68,7 @@ public class PortfolioService {
     }
 
     @Transactional
-    public String uploadPortfolioImage(MultipartFile portfolioImg, Portfolio portfolio){
+    public String uploadPortfolioImg(MultipartFile portfolioImg, Portfolio portfolio){
         String randomFilename = s3Service.s3UploadImgForCloudFront(portfolioImg);
 
         PortfolioImg img = PortfolioImg.builder()

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -42,7 +42,7 @@ public class PortfolioService {
      */
     @Transactional
     public UUID uploadPortfolio(PortfolioRequest request, Member member){
-        if (request.getPortfolioImg().size() > MAX_IMAGE_COUNT) {
+        if (request.getPortfolioImgs().size() > MAX_IMAGE_COUNT) {
             throw new CustomException(ErrorCode.PORTFOLIO_IMG_MAX_COUNT_EXCEEDED);
         }
 
@@ -55,8 +55,8 @@ public class PortfolioService {
         /**
          * Cascade 옵션을 활용해서 부모 엔티티만 Save 해서 update 쿼리 최소화
          */
-        if (request.getPortfolioImg().size() > 0) {
-            for (MultipartFile imgFile : request.getPortfolioImg()) {
+        if (request.getPortfolioImgs().size() > 0) {
+            for (MultipartFile imgFile : request.getPortfolioImgs()) {
                 String fileName = s3Upload(imgFile, portfolio);
 
                 PortfolioImg portfolioImg = PortfolioImg.builder()

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -127,7 +127,7 @@ public class PortfolioService {
      */
     private void getFileExtension(String fileName) {
         if (fileName.length() == 0) {
-            throw new CustomException(ErrorCode.WRONG_INPUT_IMAGE);
+            throw new CustomException(ErrorCode.INVALID_INPUT_IMAGE);
         }
         ArrayList<String> fileValidate = new ArrayList<>();
         fileValidate.add(".jpg");

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -138,7 +138,7 @@ public class PortfolioService {
         fileValidate.add(".PNG");
         String idxFileName = fileName.substring(fileName.lastIndexOf("."));
         if (!fileValidate.contains(idxFileName)) {
-            throw new CustomException(ErrorCode.WRONG_IMAGE_FORMAT);
+            throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
         }
     }
 }

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -43,7 +43,7 @@ public class PortfolioService {
     @Transactional
     public UUID uploadPortfolio(PortfolioRequest request, Member member){
         if (request.getPortfolioImg().size() > MAX_IMAGE_COUNT) {
-            throw new CustomException(ErrorCode.PORTFOLIO_IMG_MAX_SIZE);
+            throw new CustomException(ErrorCode.PORTFOLIO_IMG_MAX_COUNT_EXCEEDED);
         }
 
         Portfolio portfolio = Portfolio.builder()

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -48,7 +48,7 @@ public class PortfolioService {
 
         Portfolio portfolio = Portfolio.builder()
                 .member(member)
-                .publicRelations(request.getPublicRelations())
+                .portfolioDescription(request.getPortfolioDescription())
                 .portfolioType(PortfolioType.UNDER_REVIEW)
                 .build();
 

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -1,0 +1,144 @@
+package com.ticketmate.backend.service.portfolio;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.ticketmate.backend.object.dto.portfolio.request.PortfolioRequest;
+import com.ticketmate.backend.object.postgres.Member.Member;
+import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
+import com.ticketmate.backend.object.postgres.portfolio.PortfolioImg;
+import com.ticketmate.backend.repository.postgres.portfolio.PortfolioRepository;
+import com.ticketmate.backend.util.exception.CustomException;
+import com.ticketmate.backend.util.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PortfolioService {
+    private final PortfolioRepository portfolioRepository;
+    private final AmazonS3 amazonS3;
+    @Value("${cloud.aws.s3.path.portfolio.bucket}")
+    private String bucket;
+    @Value("${cloud.aws.s3.path.portfolio.cloud-front-domain}")
+    private String domain;
+    private static final Integer MAX_IMAGE = 20;
+
+    /**
+     * 포트폴리오 업로드
+     *
+     * @param request publicRelations
+     * @return 생성된 포트폴리오에 대한 고유한 UUID
+     */
+    @Transactional
+    public UUID uploadPortfolio(PortfolioRequest request, Member member){
+
+        if (request.getPortfolioImg() == null || request.getPortfolioImg().isEmpty()) {
+            throw new CustomException(ErrorCode.PORTFOLIO_IMG_BLACK);
+        }
+        if (request.getPortfolioImg().size() > MAX_IMAGE) {
+            throw new CustomException(ErrorCode.PORTFOLIO_IMG_MAX_SIZE);
+        }
+
+        Portfolio portfolio = Portfolio.builder()
+                .member(member)
+                .publicRelations(request.getPublicRelations())
+                .build();
+
+        /**
+         * Cascade 옵션을 활용해서 부모 엔티티만 Save 해서 update 쿼리 최소화
+         */
+        for (MultipartFile imgFile : request.getPortfolioImg()) {
+            String fileName = s3Upload(imgFile, portfolio);
+
+            PortfolioImg portfolioImg = PortfolioImg.builder()
+                    .imgName(fileName)
+                    .portfolio(portfolio)
+                    .build();
+
+            portfolio.addImg(portfolioImg);
+        }
+
+        portfolioRepository.save(portfolio);
+
+        log.info("총 저장된 파일 갯수 : {}", portfolio.getImgList().size());
+
+        return portfolio.getPortfolioId();
+    }
+
+
+    /**
+     * S3 버킷에 이미지를 저장하는 로직입니다.
+     */
+    @Transactional
+    public String s3Upload(MultipartFile portfolioImg, Portfolio portfolio){
+        String originalFilename = portfolioImg.getOriginalFilename();
+
+        getFileExtension(originalFilename);
+
+        // 중복이 되지 않는 고유한 파일이름 생성
+        String randomFilename = generateRandomFilename(originalFilename);
+        log.info("filename: {}", randomFilename);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(portfolioImg.getSize());
+        metadata.setContentType(portfolioImg.getContentType());
+
+        try {
+            amazonS3.putObject(bucket, randomFilename, portfolioImg.getInputStream(), metadata);
+
+        } catch (AmazonServiceException | IOException e) {
+            throw new CustomException(ErrorCode.S3_UPLOAD_ERROR);
+        }
+
+        String s3UrlString = amazonS3.getUrl(bucket, randomFilename).toString();
+        log.info("S3URL: {}", s3UrlString);
+        String cloudFrontUrl = domain + randomFilename;
+
+        log.info("ImgURL: {}", cloudFrontUrl);
+
+        PortfolioImg img = PortfolioImg.builder()
+                .imgName(randomFilename)
+                .portfolio(portfolio)
+                .build();
+
+        log.info("Img : {}", img.getImgName());
+        return randomFilename;
+    }
+
+    /**
+     * 파일 이름 생성을 위한 메서드입니다.
+     */
+    private String generateRandomFilename(String fileName) {
+        return UUID.randomUUID() + fileName;
+    }
+
+    /**
+     * 이미지 파일만 저장될 수 있도록 파일의 유효성을 검사하는 메서드입니다.
+     */
+    private void getFileExtension(String fileName) {
+        if (fileName.length() == 0) {
+            throw new CustomException(ErrorCode.WRONG_INPUT_IMAGE);
+        }
+        ArrayList<String> fileValidate = new ArrayList<>();
+        fileValidate.add(".jpg");
+        fileValidate.add(".jpeg");
+        fileValidate.add(".png");
+        fileValidate.add(".JPG");
+        fileValidate.add(".JPEG");
+        fileValidate.add(".PNG");
+        String idxFileName = fileName.substring(fileName.lastIndexOf("."));
+        if (!fileValidate.contains(idxFileName)) {
+            throw new CustomException(ErrorCode.WRONG_IMAGE_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/ticketmate/backend/service/s3/S3Service.java
+++ b/src/main/java/com/ticketmate/backend/service/s3/S3Service.java
@@ -75,19 +75,19 @@ public class S3Service {
      */
     private void validateImgFileExtension(String fileName) {
         if (fileName.length() == 0) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_IMAGE);
+            throw new CustomException(ErrorCode.INVALID_INPUT_IMG);
         }
 
         int lastDot = fileName.lastIndexOf('.');
         if (lastDot < 0) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_IMAGE);
+            throw new CustomException(ErrorCode.INVALID_INPUT_IMG);
         }
 
         String extension = fileName.substring(lastDot);
 
         // 유효 확장자 목록에 없으면 예외
         if (!ALLOWED_EXTENSIONS.contains(extension)) {
-            throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
+            throw new CustomException(ErrorCode.INVALID_IMG_FORMAT);
         }
     }
 }

--- a/src/main/java/com/ticketmate/backend/service/s3/S3Service.java
+++ b/src/main/java/com/ticketmate/backend/service/s3/S3Service.java
@@ -1,0 +1,93 @@
+package com.ticketmate.backend.service.s3;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.ticketmate.backend.util.exception.CustomException;
+import com.ticketmate.backend.util.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class S3Service {
+    @Value("${cloud.aws.s3.path.portfolio.bucket}")
+    private String bucket;
+    @Value("${cloud.aws.s3.path.portfolio.cloud-front-domain}")
+    private String domain;
+    private final AmazonS3 amazonS3;
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG");
+
+
+    /**
+     * 이미지파일을 버킷에 업로드하고 저장한 이미지파일의 이름(랜덤한 UUID가 붙은)을 반환해주는 메서드입니다.
+     */
+    public String s3UploadImgForCloudFront(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+
+        // 이미지파일 확장자 검증
+        validateImgFileExtension(originalFilename);
+
+        // 중복이 되지 않는 고유한 파일이름 생성
+        String randomFilename = generateRandomFilename(originalFilename);
+
+        log.debug("filename: {}", randomFilename);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        // 파일 업로드
+        try {
+            amazonS3.putObject(bucket, randomFilename, file.getInputStream(), metadata);
+
+        } catch (AmazonServiceException | IOException e) {
+            throw new CustomException(ErrorCode.S3_UPLOAD_ERROR);
+        }
+
+        String s3UrlString = amazonS3.getUrl(bucket, randomFilename).toString();
+        log.debug("S3URL: {}", s3UrlString);
+        String cloudFrontUrl = domain + randomFilename;
+
+        // 최종 이미지 URL 반환
+        log.debug("ImgURL: {}", cloudFrontUrl);
+
+        return randomFilename;
+    }
+
+    /**
+     * 파일 이름 생성을 위한 메서드입니다.
+     */
+    public String generateRandomFilename(String fileName) {
+        return UUID.randomUUID() + fileName;
+    }
+
+    /**
+     * 이미지 파일만 저장될 수 있도록 파일의 유효성을 검사하는 메서드입니다.
+     */
+    private void validateImgFileExtension(String fileName) {
+        if (fileName.length() == 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_IMAGE);
+        }
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot < 0) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_IMAGE);
+        }
+
+        String extension = fileName.substring(lastDot);
+
+        // 유효 확장자 목록에 없으면 예외
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new CustomException(ErrorCode.INVALID_IMAGE_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/ticketmate/backend/util/config/S3Config.java
+++ b/src/main/java/com/ticketmate/backend/util/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.ticketmate.backend.util.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -54,8 +54,22 @@ public enum ErrorCode {
 
     // FILE IO
 
-    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 중 오류가 발생했습니다.");
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 중 오류가 발생했습니다."),
 
+    // S3
+
+    S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 중 오류가 발생했습니다."),
+
+    WRONG_INPUT_IMAGE(HttpStatus.BAD_REQUEST, "파일의 이름이 잘못되었습니다."),
+
+    WRONG_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "이미지의 확장자가 잘못되었습니다. 확장자는 jpg, jpeg, png, JPG, JPEG, PNG 만 가능합니다"),
+
+
+    // PORTFOLIO
+
+    PORTFOLIO_IMG_BLACK(HttpStatus.BAD_REQUEST, "자신을 소개할 수 있는 포트폴리오 이미지를 첨부해주세요."),
+
+    PORTFOLIO_IMG_MAX_SIZE(HttpStatus.BAD_REQUEST, "포트폴리오 등록을 위한 이미지는 최대 20장입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -62,7 +62,7 @@ public enum ErrorCode {
 
     INVALID_INPUT_IMAGE(HttpStatus.BAD_REQUEST, "파일의 이름이 잘못되었습니다."),
 
-    WRONG_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "이미지의 확장자가 잘못되었습니다. 확장자는 jpg, jpeg, png, JPG, JPEG, PNG 만 가능합니다"),
+    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "이미지의 확장자가 잘못되었습니다. 확장자는 jpg, jpeg, png, JPG, JPEG, PNG 만 가능합니다"),
 
 
     // PORTFOLIO

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -69,7 +69,7 @@ public enum ErrorCode {
 
     PORTFOLIO_IMG_BLACK(HttpStatus.BAD_REQUEST, "자신을 소개할 수 있는 포트폴리오 이미지를 첨부해주세요."),
 
-    PORTFOLIO_IMG_MAX_SIZE(HttpStatus.BAD_REQUEST, "포트폴리오 등록을 위한 이미지는 최대 20장입니다.");
+    PORTFOLIO_IMG_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "포트폴리오 등록을 위한 이미지는 최대 20장입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -60,7 +60,7 @@ public enum ErrorCode {
 
     S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 중 오류가 발생했습니다."),
 
-    WRONG_INPUT_IMAGE(HttpStatus.BAD_REQUEST, "파일의 이름이 잘못되었습니다."),
+    INVALID_INPUT_IMAGE(HttpStatus.BAD_REQUEST, "파일의 이름이 잘못되었습니다."),
 
     WRONG_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "이미지의 확장자가 잘못되었습니다. 확장자는 jpg, jpeg, png, JPG, JPEG, PNG 만 가능합니다"),
 

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -60,9 +60,9 @@ public enum ErrorCode {
 
     S3_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 중 오류가 발생했습니다."),
 
-    INVALID_INPUT_IMAGE(HttpStatus.BAD_REQUEST, "파일의 이름이 잘못되었습니다."),
+    INVALID_INPUT_IMG(HttpStatus.BAD_REQUEST, "파일의 이름이 잘못되었습니다."),
 
-    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "이미지의 확장자가 잘못되었습니다. 확장자는 jpg, jpeg, png, JPG, JPEG, PNG 만 가능합니다"),
+    INVALID_IMG_FORMAT(HttpStatus.BAD_REQUEST, "이미지의 확장자가 잘못되었습니다. 확장자는 jpg, jpeg, png, JPG, JPEG, PNG 만 가능합니다"),
 
 
     // PORTFOLIO


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

# 의뢰자 -> 대리인으로 변경하기 위한 포트폴리오 업로드 API 설계

- **MULTIPART_FORM_DATA_VALUE** 형식으로 데이터를 받습니다.
- 파일은 최대 20개까지 업로드 가능합니다.
- 이미지파일의 형식이 아니라면 예외가 발생합니다.
- 자기소개는 자기소개는 20자 이상, 200자 이하로 입력해야 합니다.
- S3와 CloudFornt와 연동해 이미지 URL을 도메인에 맞게 수정합니다.

TODO : 포트폴리오 업로드에 대한 테스트코드 작성 (현재 Service 유닛 테스트는 완료했지만 컨트롤러 테스팅은 시큐리티 관련해서 실패합니다.)

## ✅ 테스트
---
- [x] 수동 테스트 완료
- [ ] 테스트 코드 완료
