### PR TITLE
[기능추가][관리자] 의뢰인 -> 대리자를 희밍하는 포트폴리오에 관한 반려, 승인 API 구현 #101

### DIFF
--- a/src/main/java/com/ticketmate/backend/controller/admin/AdminController.java
+++ b/src/main/java/com/ticketmate/backend/controller/admin/AdminController.java
@@ -2,6 +2,7 @@ package com.ticketmate.backend.controller.admin;
 
 import com.ticketmate.backend.controller.admin.docs.AdminControllerDocs;
 import com.ticketmate.backend.object.dto.admin.request.PortfolioSearchRequest;
+import com.ticketmate.backend.object.dto.admin.request.PortfolioStatusUpdateRequest;
 import com.ticketmate.backend.object.dto.admin.response.PortfolioForAdminResponse;
 import com.ticketmate.backend.object.dto.admin.response.PortfolioListForAdminResponse;
 import com.ticketmate.backend.object.dto.auth.request.CustomOAuth2User;
@@ -67,5 +68,15 @@ public class AdminController implements AdminControllerDocs {
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
             @PathVariable(value = "portfolio-id") UUID portfolioId) {
         return ResponseEntity.ok(adminService.getPortfolio(portfolioId));
+    }
+
+    @Override
+    @PatchMapping(value = "/portfolio/list/{portfolio-id}")
+    @LogMonitoringInvocation
+    public ResponseEntity<UUID> reviewPortfolio(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @PathVariable(value = "portfolio-id") UUID portfolioId,
+            @RequestBody @Valid PortfolioStatusUpdateRequest request) {
+        return ResponseEntity.ok(adminService.reviewPortfolioCompleted(portfolioId, request));
     }
 }

--- a/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
@@ -1,6 +1,7 @@
 package com.ticketmate.backend.controller.admin.docs;
 
 import com.ticketmate.backend.object.dto.admin.request.PortfolioSearchRequest;
+import com.ticketmate.backend.object.dto.admin.request.PortfolioStatusUpdateRequest;
 import com.ticketmate.backend.object.dto.admin.response.PortfolioForAdminResponse;
 import com.ticketmate.backend.object.dto.admin.response.PortfolioListForAdminResponse;
 import com.ticketmate.backend.object.dto.auth.request.CustomOAuth2User;
@@ -119,4 +120,29 @@ public interface AdminControllerDocs {
     )
     ResponseEntity<PortfolioForAdminResponse> getPortfolioInfo(
             CustomOAuth2User customOAuth2User, UUID portfolioId);
+
+    @Operation(
+            summary = "요청한 포트폴리오 승인, 반려처리",
+            description = """
+                                        
+                    이 API는 관리자 인증이 필요합니다
+                    
+                    ### 요청 파라미터
+                    - 변경할 포트폴리오의 고유한 id
+                    - 반려 및 승인의 Body 파라미터
+                    
+                    ### PortfolioType
+                    
+                    REVIEW_COMPLETED ("승인된 포트폴리오")
+                    
+                    COMPANION("반려된 포트폴리오")
+                                
+                    ### 유의사항
+                    - 관리자가 승인 요청이된 포트폴리오를 승인 및 반려하는 작업입니다.
+                    - 승인(REVIEW_COMPLETED)시 해당 포트폴리오의 상태가 "REVIEW_COMPLETED("승인된 포트폴리오")" 로 변경됩니다.
+                    - 반려(COMPANION)시 해당 포트폴리오의 상태가 "COMPANION("반려된 포트폴리오")" 로 변경됩니다. 
+                    """
+    )
+    ResponseEntity<UUID> reviewPortfolio(
+            CustomOAuth2User customOAuth2User, UUID portfolioId, PortfolioStatusUpdateRequest request);
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/admin/request/PortfolioStatusUpdateRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/admin/request/PortfolioStatusUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.ticketmate.backend.object.dto.admin.request;
+
+import com.ticketmate.backend.object.constants.PortfolioType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class PortfolioStatusUpdateRequest {
+    @Schema(defaultValue = "REVIEW_COMPLETED")
+    private PortfolioType portfolioType;
+}

--- a/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
+++ b/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
@@ -1,8 +1,10 @@
 package com.ticketmate.backend.service.admin;
 
 import com.ticketmate.backend.object.constants.City;
+import com.ticketmate.backend.object.constants.MemberType;
 import com.ticketmate.backend.object.constants.PortfolioType;
 import com.ticketmate.backend.object.dto.admin.request.PortfolioSearchRequest;
+import com.ticketmate.backend.object.dto.admin.request.PortfolioStatusUpdateRequest;
 import com.ticketmate.backend.object.dto.admin.response.PortfolioForAdminResponse;
 import com.ticketmate.backend.object.dto.admin.response.PortfolioListForAdminResponse;
 import com.ticketmate.backend.object.dto.concert.request.ConcertInfoRequest;
@@ -172,6 +174,33 @@ public class AdminService {
         portfolioForAdminResponse.addPortfolioImg(portfolioImgList);
 
         return portfolioForAdminResponse;
+    }
+
+    /**
+     * 관리자의 포트폴리오 승인 및 반려처리 로직
+     * @param portfolioId (UUID)
+     *        PortfolioType (포트폴리오 상태)
+     */
+    @Transactional
+    public UUID reviewPortfolioCompleted(UUID portfolioId, PortfolioStatusUpdateRequest request) {
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PORTFOLIO_NOT_FOUND));
+
+        log.debug("변경전 포트폴리오 TYPE: {}", portfolio.getPortfolioType());
+
+        // 승인
+        if (request.getPortfolioType().equals(PortfolioType.REVIEW_COMPLETED)) {
+            portfolio.setPortfolioType(PortfolioType.REVIEW_COMPLETED);
+            log.debug("승인완료: {}", portfolio.getPortfolioType());
+
+            portfolio.getMember().setMemberType(MemberType.AGENT);
+        } else {
+            // 반려
+            portfolio.setPortfolioType(PortfolioType.COMPANION);
+            log.debug("반려완료: {}", portfolio.getPortfolioType());
+        }
+
+        return portfolio.getPortfolioId();
     }
 
 


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

# API 명세
<img width="1142" alt="스크린샷 2025-02-25 오후 5 01 59" src="https://github.com/user-attachments/assets/74821cdf-91f6-4213-951f-6ee855dc7e1c" />


# 요청 파라미터
<img width="1129" alt="스크린샷 2025-02-25 오후 5 02 13" src="https://github.com/user-attachments/assets/d419d612-c0a1-4e42-a767-e57874a0ab2f" />

# 응답예시

- 변경된 포트폴리오 id
`"523c6fce-da1b-4e5c-a0c7-f529df075ebc"`


## ✅ 테스트
---
- [x] 수동 테스트 완료
- [ ] 테스트 코드 완료
