### PR TITLE
⚙️ [기능추가][FCM] FCM 토큰을 핸들링하기 위한 적절한 처리 방법 구현 #116

### DIFF
--- a/src/main/java/com/ticketmate/backend/controller/fcm/FcmController.java
+++ b/src/main/java/com/ticketmate/backend/controller/fcm/FcmController.java
@@ -1,0 +1,38 @@
+package com.ticketmate.backend.controller.fcm;
+
+import com.ticketmate.backend.controller.fcm.docs.FcmControllerDocs;
+import com.ticketmate.backend.object.dto.auth.request.CustomOAuth2User;
+import com.ticketmate.backend.object.dto.fcm.request.FcmTokenSaveRequest;
+import com.ticketmate.backend.object.dto.fcm.response.FcmTokenSaveResponse;
+import com.ticketmate.backend.object.postgres.Member.Member;
+import com.ticketmate.backend.service.fcm.FcmService;
+import com.ticketmate.backend.util.log.LogMonitoringInvocation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm")
+@Tag(
+        name = "FCM 관련 API",
+        description = "FCM 관련 API 제공"
+)
+public class FcmController implements FcmControllerDocs {
+    private final FcmService fcmService;
+    @Override
+    @PostMapping(value = "")
+    @LogMonitoringInvocation
+    public ResponseEntity<FcmTokenSaveResponse> saveFcmToken(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @RequestBody @Valid FcmTokenSaveRequest request) {
+        Member member = customOAuth2User.getMember();
+        return ResponseEntity.ok(fcmService.saveFcmToken(request,member));
+    }
+}

--- a/src/main/java/com/ticketmate/backend/controller/fcm/docs/FcmControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/fcm/docs/FcmControllerDocs.java
@@ -1,0 +1,42 @@
+package com.ticketmate.backend.controller.fcm.docs;
+
+import com.ticketmate.backend.object.dto.auth.request.CustomOAuth2User;
+import com.ticketmate.backend.object.dto.fcm.request.FcmTokenSaveRequest;
+import com.ticketmate.backend.object.dto.fcm.response.FcmTokenSaveResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+
+public interface FcmControllerDocs {
+    @Operation(
+            summary = "클라이언트로부터 발급한 FCM 토큰 및 사용자의 기기정보를 받아 저장하는 API 입니다.",
+            description = """
+                                        
+                    이 API는 인증이 필요합니다.
+
+                    ### 요청 파라미터
+                    - **fmcToken** (String): FCM 토큰값 [필수]
+                    - **memberPlatform** (String): 사용자 기기값 [필수]
+                                        
+                    ### MemberPlatform
+                                        
+                        ANDROID("안드로이드")
+                        IOS("애플")
+                        WEB("웹")
+                        OTHER("기타")
+                        
+                    ### 반환값                                        
+                       - tokenId [String] (서버에 저장된 fcm 엔티티의 PK값)
+                       - fmcToken [String] (반환할 fcm 토큰값)
+                       - memberId [String] (사용자 PK)
+                       - memberPlatform [String] (로그인한 사용자 기기종류)
+                                        
+                                        
+                    ### 유의사항
+                    - FCM 토큰과 ios, 안드로이드, 웹페이지로부터 각각의 사용자 기기정보를 받습니다.
+                    - 사용자당 최소 1개 이상의 FCM 토큰이 있을 수 있습니다 (사용자의 다중 기기접속시 1:N)
+                    """
+    )
+    ResponseEntity<FcmTokenSaveResponse> saveFcmToken(
+            CustomOAuth2User customOAuth2User,
+            FcmTokenSaveRequest request);
+}

--- a/src/main/java/com/ticketmate/backend/object/constants/MemberPlatform.java
+++ b/src/main/java/com/ticketmate/backend/object/constants/MemberPlatform.java
@@ -1,0 +1,15 @@
+package com.ticketmate.backend.object.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum MemberPlatform {
+    ANDROID("안드로이드"),
+    IOS("애플"),
+    WEB("웹"),
+    OTHER("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/ticketmate/backend/object/dto/fcm/request/FcmTokenSaveRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/fcm/request/FcmTokenSaveRequest.java
@@ -1,0 +1,20 @@
+package com.ticketmate.backend.object.dto.fcm.request;
+
+
+import com.ticketmate.backend.object.constants.MemberPlatform;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@ToString
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class FcmTokenSaveRequest {
+    @NotBlank(message = "FCM 토큰을 입력해주세요")
+    @Schema(defaultValue = "chM0thKFkDxdhMm5WAMMwQ:APA91bGKs8nN4A_bPClciFu88Z2bgN9-gvPKsopGsxPcKS2K86Gu9JcZi0HPHgcwpONymKpTiMPE4ztmIt0qXOl9gKUom13Aze80CkvPE6JwEuAgxJDRGtg")
+    private String fmcToken; // FCM 토큰
+
+    private MemberPlatform memberPlatform;
+}

--- a/src/main/java/com/ticketmate/backend/object/dto/fcm/response/FcmTokenSaveResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/fcm/response/FcmTokenSaveResponse.java
@@ -1,0 +1,19 @@
+package com.ticketmate.backend.object.dto.fcm.response;
+
+
+import com.ticketmate.backend.object.constants.MemberPlatform;
+import lombok.*;
+
+import java.util.UUID;
+
+@ToString
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class FcmTokenSaveResponse {
+    private String tokenId;  // 서버에 저장된 fcm 엔티티의 PK값
+    private String fcmToken;  // 반환할 fcm 토큰값
+    private UUID memberId;  // 사용자 PK
+    private MemberPlatform memberPlatform;  // 로그인한 사용자 기기종류
+}

--- a/src/main/java/com/ticketmate/backend/object/redis/FcmToken.java
+++ b/src/main/java/com/ticketmate/backend/object/redis/FcmToken.java
@@ -1,0 +1,28 @@
+package com.ticketmate.backend.object.redis;
+
+import com.ticketmate.backend.object.constants.MemberPlatform;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@RedisHash(value = "fcmToken", timeToLive = 2592000)  // 30일 지나면 파기
+@Setter
+public class FcmToken {
+    @Id
+    private String tokenId; // 회원 PK + "-" + MemberPlatform 형태
+    private String fcmToken;  // FCM 토큰
+    private UUID memberId;  // 사용자의 PK
+    private MemberPlatform memberPlatform;  // 토큰을 받은 사용자의 기기종류
+
+    @Builder
+    public FcmToken(String fcmToken, UUID memberId, MemberPlatform memberPlatform) {
+        this.tokenId = memberId + "-" + memberPlatform;
+        this.fcmToken = fcmToken;
+        this.memberId = memberId;
+        this.memberPlatform = memberPlatform;
+    }
+}

--- a/src/main/java/com/ticketmate/backend/repository/redis/FcmTokenRepository.java
+++ b/src/main/java/com/ticketmate/backend/repository/redis/FcmTokenRepository.java
@@ -1,0 +1,9 @@
+package com.ticketmate.backend.repository.redis;
+
+import com.ticketmate.backend.object.redis.FcmToken;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.UUID;
+
+public interface FcmTokenRepository extends CrudRepository<FcmToken, UUID> {
+}

--- a/src/main/java/com/ticketmate/backend/service/fcm/FcmService.java
+++ b/src/main/java/com/ticketmate/backend/service/fcm/FcmService.java
@@ -1,0 +1,42 @@
+package com.ticketmate.backend.service.fcm;
+
+import com.ticketmate.backend.object.dto.fcm.request.FcmTokenSaveRequest;
+import com.ticketmate.backend.object.dto.fcm.response.FcmTokenSaveResponse;
+import com.ticketmate.backend.object.postgres.Member.Member;
+import com.ticketmate.backend.object.redis.FcmToken;
+import com.ticketmate.backend.repository.redis.FcmTokenRepository;
+import com.ticketmate.backend.util.common.EntityMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmService {
+    private final FcmTokenRepository fcmTokenRepository;
+    private final EntityMapper mapper;
+
+    /**
+     * RedisHash에 FCM 토큰이 저장되는 로직입니다.
+     */
+    @Transactional
+    public FcmTokenSaveResponse saveFcmToken(FcmTokenSaveRequest request, Member member) {
+        // DTO -> 엔티티
+        FcmToken fcmToken = FcmToken.builder()
+                .fcmToken(request.getFmcToken())
+                .memberId(member.getMemberId())
+                .memberPlatform(request.getMemberPlatform())
+                .build();
+
+        // 같은 키(memberId-platform)에 대해 호출 시 기존 데이터가 자동으로 덮어써짐 (사용자의 기기마다 토큰값은 유일하게 설계)
+        fcmTokenRepository.save(fcmToken);
+
+        log.debug("토큰 저장 완료");
+        log.debug("사용자 ID : {}", fcmToken.getMemberId());
+        log.debug("사용자 기기 : {}", fcmToken.getMemberPlatform());
+
+        return mapper.toFcmTokenSaveResponse(fcmToken);
+    }
+}

--- a/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
+++ b/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
@@ -4,9 +4,11 @@ import com.ticketmate.backend.object.dto.admin.response.PortfolioForAdminRespons
 import com.ticketmate.backend.object.dto.admin.response.PortfolioListForAdminResponse;
 import com.ticketmate.backend.object.dto.concert.response.ConcertFilteredResponse;
 import com.ticketmate.backend.object.dto.concerthall.response.ConcertHallFilteredResponse;
+import com.ticketmate.backend.object.dto.fcm.response.FcmTokenSaveResponse;
 import com.ticketmate.backend.object.postgres.concert.Concert;
 import com.ticketmate.backend.object.postgres.concerthall.ConcertHall;
 import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
+import com.ticketmate.backend.object.redis.FcmToken;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -31,4 +33,7 @@ public interface EntityMapper {
     @Mapping(source = "member.profileUrl", target = "profileUrl")
     @Mapping(source = "member.memberType", target = "memberType")
     PortfolioForAdminResponse toPortfolioForAdminResponse(Portfolio portfolio);
+
+    // FcmToken -> FcmTokenSaveResponse
+    FcmTokenSaveResponse toFcmTokenSaveResponse(FcmToken fcmToken);
 }


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

## 토큰 저장 요청예시 (로그인 후)
<img width="1141" alt="스크린샷 2025-03-03 오후 3 55 02" src="https://github.com/user-attachments/assets/74878d34-7299-479e-ba1c-f548b6ae9685" />

## 응답예시
<img width="1122" alt="스크린샷 2025-03-03 오후 3 56 02" src="https://github.com/user-attachments/assets/f7b2fd28-9052-4038-9386-6f8c2f9bf718" />

자세한 내용 : https://github.com/Team-TicketMate/ticketmate-server/issues/116

## TODO 
- n일 이상 미접속 이용자 → 자동 로그아웃 처리로 간주 → 해당 토큰 삭제 
- RedisHash를 이용한 TTL 전략 (”얼마나 오래 미사용하면 파기할지”에 대한 비즈니스 결정 필요함.)
- 현재 임의로 30일로 설정해놓음(회의때 결정 필요)


## ✅ 테스트
---
- [x] 수동 테스트 완료
- [ ] 테스트 코드 완료
