### PR TITLE
⚙️ [기능추가][FCM] FCM 알림 전송내용 현재 기능에 추가 #148

### DIFF
--- a/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
@@ -112,10 +112,16 @@ public interface AdminControllerDocs {
                     이 API는 관리자 인증이 필요합니다
                     
                     ### 요청 파라미터
-                    - 포트폴리오의 고유한 id
+                    - 포트폴리오의 고유한 id                  
                                 
                     ### 유의사항
-                    - 포트폴리오의 id를 활용해 포트폴리오 상세조회시 관라지에게 필요한 데이터를 반환합니다. 
+                    - 포트폴리오의 id를 활용해 포트폴리오 상세조회시 관라지에게 필요한 데이터를 반환합니다.
+                   
+                    ### 알림전송 특이사항
+                    - **UNDER_REVIEW** 상태의 포트폴리오를 **REVIEWING** 상태로 변경합니다.
+                    - 변경하며 해당 포트폴리오를 올린 사용자에 대해서 알림을 발송합니다.
+                    - 백엔드측 알림구현은 Web푸시 알림을 구현하여 전송합니다.
+                    - 푸시알림시 1:N 플랫폼의 사용자를 대비하기 위해 기존에 만들어놓은 RedisHash스키마를 활용하여 사용자의 모든 플랫폼에 알림을 전송합니다.
                     """
     )
     ResponseEntity<PortfolioForAdminResponse> getPortfolioInfo(
@@ -141,6 +147,12 @@ public interface AdminControllerDocs {
                     - 관리자가 승인 요청이된 포트폴리오를 승인 및 반려하는 작업입니다.
                     - 승인(REVIEW_COMPLETED)시 해당 포트폴리오의 상태가 "REVIEW_COMPLETED("승인된 포트폴리오")" 로 변경됩니다.
                     - 반려(COMPANION)시 해당 포트폴리오의 상태가 "COMPANION("반려된 포트폴리오")" 로 변경됩니다. 
+                    
+                    ### 알림전송 특이사항
+                    - 관리자가 포트폴리오를 승인 혹은 반려 상태로 변경합니다.
+                    - 상태가 변경되면 해당 포트폴리오를 올린 사용자에 대해서 알림을 발송합니다.
+                    - 백엔드측 알림구현은 Web푸시 알림을 구현하여 전송합니다.
+                    - 푸시알림시 1:N 플랫폼의 사용자를 대비하기 위해 기존에 만들어놓은 RedisHash스키마를 활용하여 사용자의 모든 플랫폼에 알림을 전송합니다.
                     """
     )
     ResponseEntity<UUID> reviewPortfolio(

--- a/src/main/java/com/ticketmate/backend/object/dto/notification/request/NotificationPayloadRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/notification/request/NotificationPayloadRequest.java
@@ -1,0 +1,17 @@
+package com.ticketmate.backend.object.dto.notification.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NotificationPayloadRequest {
+    private String title;
+    private String body;
+
+    @Builder
+    public NotificationPayloadRequest(String title, String body) {
+        this.title = title;
+        this.body = body;
+    }
+}

--- a/src/main/java/com/ticketmate/backend/object/redis/FcmToken.java
+++ b/src/main/java/com/ticketmate/backend/object/redis/FcmToken.java
@@ -4,6 +4,7 @@ import com.ticketmate.backend.object.constants.MemberPlatform;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
 import java.util.UUID;
 
@@ -15,6 +16,7 @@ public class FcmToken {
     @Id
     private String tokenId; // 회원 PK + "-" + MemberPlatform 형태
     private String fcmToken;  // FCM 토큰
+    @Indexed
     private UUID memberId;  // 사용자의 PK
     private MemberPlatform memberPlatform;  // 토큰을 받은 사용자의 기기종류
 

--- a/src/main/java/com/ticketmate/backend/repository/redis/FcmTokenRepository.java
+++ b/src/main/java/com/ticketmate/backend/repository/redis/FcmTokenRepository.java
@@ -3,7 +3,9 @@ package com.ticketmate.backend.repository.redis;
 import com.ticketmate.backend.object.redis.FcmToken;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface FcmTokenRepository extends CrudRepository<FcmToken, UUID> {
+    List<FcmToken> findAllByMemberId(UUID memberId);
 }

--- a/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
+++ b/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
@@ -9,6 +9,7 @@ import com.ticketmate.backend.object.dto.admin.response.PortfolioForAdminRespons
 import com.ticketmate.backend.object.dto.admin.response.PortfolioListForAdminResponse;
 import com.ticketmate.backend.object.dto.concert.request.ConcertInfoRequest;
 import com.ticketmate.backend.object.dto.concerthall.request.ConcertHallInfoRequest;
+import com.ticketmate.backend.object.dto.notification.request.NotificationPayloadRequest;
 import com.ticketmate.backend.object.postgres.concert.Concert;
 import com.ticketmate.backend.object.postgres.concerthall.ConcertHall;
 import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
@@ -170,8 +171,10 @@ public class AdminService {
 
         UUID memberId = portfolio.getMember().getMemberId();
 
-        String notificationMessage = notificationUtil.portfolioNotification(PortfolioType.REVIEWING, portfolio);
-        fcmService.sendNotification(memberId, notificationMessage);
+        NotificationPayloadRequest payload = notificationUtil
+                .portfolioNotification(PortfolioType.REVIEWING, portfolio);
+
+        fcmService.sendNotification(memberId, payload);
 
         PortfolioForAdminResponse portfolioForAdminResponse = entityMapper.toPortfolioForAdminResponse(portfolio);
 
@@ -185,7 +188,6 @@ public class AdminService {
 
         return portfolioForAdminResponse;
     }
-
     /**
      * 관리자의 포트폴리오 승인 및 반려처리 로직
      * @param portfolioId (UUID)
@@ -207,15 +209,19 @@ public class AdminService {
 
             portfolio.getMember().setMemberType(MemberType.AGENT);
 
-            String notificationMessage = notificationUtil.portfolioNotification(PortfolioType.REVIEW_COMPLETED, portfolio);
-            fcmService.sendNotification(memberId, notificationMessage);
+            NotificationPayloadRequest payload = notificationUtil
+                    .portfolioNotification(PortfolioType.REVIEW_COMPLETED, portfolio);
+
+            fcmService.sendNotification(memberId, payload);
         } else {
             // 반려
             portfolio.setPortfolioType(PortfolioType.COMPANION);
             log.debug("반려완료: {}", portfolio.getPortfolioType());
 
-            String notificationMessage = notificationUtil.portfolioNotification(PortfolioType.COMPANION, portfolio);
-            fcmService.sendNotification(memberId, notificationMessage);
+            NotificationPayloadRequest payload = notificationUtil
+                    .portfolioNotification(PortfolioType.COMPANION, portfolio);
+
+            fcmService.sendNotification(memberId, payload);
         }
 
         return portfolio.getPortfolioId();

--- a/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
+++ b/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
@@ -13,7 +13,6 @@ import com.ticketmate.backend.object.postgres.concert.Concert;
 import com.ticketmate.backend.object.postgres.concerthall.ConcertHall;
 import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
 import com.ticketmate.backend.object.postgres.portfolio.PortfolioImg;
-import com.ticketmate.backend.object.redis.FcmToken;
 import com.ticketmate.backend.repository.postgres.concert.ConcertRepository;
 import com.ticketmate.backend.repository.postgres.concerthall.ConcertHallRepository;
 import com.ticketmate.backend.repository.postgres.portfolio.PortfolioRepository;
@@ -168,8 +167,6 @@ public class AdminService {
         portfolio.setPortfolioType(PortfolioType.REVIEWING);
 
         UUID memberId = portfolio.getMember().getMemberId();
-        List<FcmToken> memberTokenList = fcmTokenRepository.findAllByMemberId(memberId);
-        log.debug("token정보 : {}", memberTokenList.get(0).getTokenId());
 
         String notificationMessage = reviewingNotificationMessage(portfolio);
         fcmService.sendNotification(memberId, notificationMessage);

--- a/src/main/java/com/ticketmate/backend/service/fcm/FcmService.java
+++ b/src/main/java/com/ticketmate/backend/service/fcm/FcmService.java
@@ -1,15 +1,24 @@
 package com.ticketmate.backend.service.fcm;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushNotification;
 import com.ticketmate.backend.object.dto.fcm.request.FcmTokenSaveRequest;
 import com.ticketmate.backend.object.dto.fcm.response.FcmTokenSaveResponse;
 import com.ticketmate.backend.object.postgres.Member.Member;
 import com.ticketmate.backend.object.redis.FcmToken;
 import com.ticketmate.backend.repository.redis.FcmTokenRepository;
 import com.ticketmate.backend.util.common.EntityMapper;
+import com.ticketmate.backend.util.exception.CustomException;
+import com.ticketmate.backend.util.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -39,4 +48,69 @@ public class FcmService {
 
         return entityMapper.toFcmTokenSaveResponse(fcmToken);
     }
+
+    /**
+     *
+     * @param memberId (알림을 보낼 회원의 PK)
+     * @param notificationMessage (전송할 알림의 내용)
+     */
+    public void sendNotification(UUID memberId, String notificationMessage) {
+        List<FcmToken> memberTokenList = fcmTokenRepository.findAllByMemberId(memberId);
+
+        if (memberTokenList.isEmpty()) {  // 토큰이 없을 경우 검증
+            throw new CustomException(ErrorCode.FCM_TOKEN_NOT_FOUND);
+        }
+
+        if (memberTokenList.size() > 1) {  // 사용자의 기기가 1개 이상일 경우 (동시접속)
+            for (FcmToken fcmToken : memberTokenList) {
+                sendWebNotification(fcmToken, notificationMessage);
+                log.debug("다중 기기 알림전송 완료");
+                log.debug("전송된 기기 : {}", fcmToken.getMemberPlatform());
+                log.debug("알림 내용 : {}", notificationMessage);
+            }
+        } else {  // 사용자의 기기가 1개일경우
+            FcmToken fcmToken = memberTokenList.get(0);
+            sendWebNotification(fcmToken, notificationMessage);
+            log.debug("단일기기 알림전송 완료");
+            log.debug("전송된 기기 : {}", fcmToken.getMemberPlatform());
+            log.debug("알림 내용 : {}", notificationMessage);
+
+        }
+    }
+
+    /**
+     * 실질적인 알림전송 로직
+     */
+    @Transactional
+    public void sendWebNotification(FcmToken fcmToken, String bodyMessage) {
+        try {
+            // WebpushNotification 생성 (알림 제목, 본문, 아이콘 URL 등 설정)
+            WebpushNotification webpushNotification = WebpushNotification.builder()
+                    .setTitle("notification")
+                    .setBody(bodyMessage)
+//                    .setIcon("") 추후 저희 어플리케이션 아이콘이 있다면 추가하면 됩니다.
+                    .build();
+
+            // 웹푸시용 설정 구성 (TTL 등의 헤더 옵션 추가 가능)
+            WebpushConfig webpushConfig = WebpushConfig.builder()
+                    .setNotification(webpushNotification)
+                    .putHeader("ttl", "300")
+                    .build();
+
+            // 대상 토큰과 웹푸시 설정을 포함하는 Message 생성
+            Message message = Message.builder()
+                    .setToken(fcmToken.getFcmToken())
+                    .setWebpushConfig(webpushConfig)
+                    .build();
+
+            // FirebaseMessaging을 통해 메시지 전송
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.debug("알림전송 완료: {}", response);
+
+        } catch (Exception e) {
+            log.debug("웹 푸시알림중 에러 발생: {}", e.getMessage());
+        }
+    }
+
+//    TODO: 추후 전체사용자에 대한 알림전송이 필요하다면 비동기처리로 새로운 로직 설계
 }

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -85,7 +85,7 @@ public enum ErrorCode {
 
     PORTFOLIO_IMG_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "포트폴리오 등록을 위한 이미지는 최대 20장입니다."),
 
-    // Redis Lock
+    // REDIS_LOCK
     LOCK_ACQUISITION_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "락 획득에 실패했습니다."),
 
     LOCK_ACQUISITION_INTERRUPT(HttpStatus.INTERNAL_SERVER_ERROR, "락 획득 중 인터럽트가 발생했습니다."),
@@ -96,7 +96,11 @@ public enum ErrorCode {
 
     HOPE_AREAS_SIZE_EXCEED(HttpStatus.BAD_REQUEST, "회망구역은 최대 10개까지만 등록 가능합니다."),
 
-    PRIORITY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "요청한 순위가 이미 설정되어있습니다.");
+    PRIORITY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "요청한 순위가 이미 설정되어있습니다."),
+
+    // NOTIFICATION
+
+    FCM_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "fcm 토큰 획득에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ticketmate/backend/util/notification/NotificationType.java
+++ b/src/main/java/com/ticketmate/backend/util/notification/NotificationType.java
@@ -1,0 +1,56 @@
+package com.ticketmate.backend.util.notification;
+
+import com.ticketmate.backend.object.constants.PortfolioType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@AllArgsConstructor
+@Getter
+public enum NotificationType {
+    /*
+   ======================================포트폴리오======================================
+    */
+    REVIEWING("포트폴리오 검토중","관리자가 {nickname} 님의 포트폴리오를 검토중입니다."),
+
+    REVIEW_COMPLETED("포트폴리오 승인 완료","{nickname} 님의 포트폴리오가 관리자에 의해 승인처리 되었습니다."),
+
+    COMPANION("포트폴리오 반려","{nickname} 님의 포트폴리오가 관리자에 의해 반려처리 되었습니다.");
+
+    /*
+   ======================================추후 필요한 알림 템플릿 작성======================================
+    */
+
+
+    private final String title;
+    private final String messageBody;
+
+    /**
+     * 메시지 템플릿에 {nickname} 변수를 치환해주는 메서드입니다.
+     */
+    public String formatMessage(String nickname) {
+        if (nickname == null) {
+            nickname = "알 수 없음";
+        }
+        return messageBody.replace("{nickname}", nickname);
+    }
+
+    /**
+     * (1) PortfolioType → NotificationType 매핑용 Map
+     */
+    private static final Map<PortfolioType, NotificationType> MAPPING = new HashMap<>();
+    static {
+        MAPPING.put(PortfolioType.REVIEWING, REVIEWING);
+        MAPPING.put(PortfolioType.REVIEW_COMPLETED, REVIEW_COMPLETED);
+        MAPPING.put(PortfolioType.COMPANION, COMPANION);
+    }
+
+    /**
+     * (2) 정적 메서드로 매핑된 NotificationType 얻기
+     */
+    public static NotificationType from(PortfolioType portfolioType) {
+        return MAPPING.get(portfolioType);
+    }
+}

--- a/src/main/java/com/ticketmate/backend/util/notification/NotificationUtil.java
+++ b/src/main/java/com/ticketmate/backend/util/notification/NotificationUtil.java
@@ -1,0 +1,28 @@
+package com.ticketmate.backend.util.notification;
+
+import com.ticketmate.backend.object.constants.PortfolioType;
+import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationUtil {
+
+    /**
+     * 포트폴리오 관련 알림내용을 만들어주는 메서드입니다.
+     */
+    public String portfolioNotification(PortfolioType portfolioType, Portfolio portfolio) {
+        // 검토중일때 전송될 알림입니다.
+        if (portfolioType.equals(PortfolioType.REVIEWING)) {
+            return "관리자가 " + portfolio.getMember().getNickname() + " 님의 포트폴리오를 검토중입니다.";
+
+            // 승인시 전송될 알림입니다.
+        } else if (portfolioType.equals(PortfolioType.REVIEW_COMPLETED)) {
+            return portfolio.getMember().getNickname() + " 님의 포트폴리오가 관리자에 의해 승인처리 되었습니다.";
+
+            // 반려시 전송될 알림입니다.
+        } else if (portfolioType.equals(PortfolioType.COMPANION)) {
+            return portfolio.getMember().getNickname() + " 님의 포트폴리오가 관리자에 의해 반려처리 되었습니다.";
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/ticketmate/backend/util/notification/NotificationUtil.java
+++ b/src/main/java/com/ticketmate/backend/util/notification/NotificationUtil.java
@@ -1,7 +1,10 @@
 package com.ticketmate.backend.util.notification;
 
 import com.ticketmate.backend.object.constants.PortfolioType;
+import com.ticketmate.backend.object.dto.notification.request.NotificationPayloadRequest;
 import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
+import com.ticketmate.backend.util.exception.CustomException;
+import com.ticketmate.backend.util.exception.ErrorCode;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -10,19 +13,24 @@ public class NotificationUtil {
     /**
      * 포트폴리오 관련 알림내용을 만들어주는 메서드입니다.
      */
-    public String portfolioNotification(PortfolioType portfolioType, Portfolio portfolio) {
-        // 검토중일때 전송될 알림입니다.
-        if (portfolioType.equals(PortfolioType.REVIEWING)) {
-            return "관리자가 " + portfolio.getMember().getNickname() + " 님의 포트폴리오를 검토중입니다.";
-
-            // 승인시 전송될 알림입니다.
-        } else if (portfolioType.equals(PortfolioType.REVIEW_COMPLETED)) {
-            return portfolio.getMember().getNickname() + " 님의 포트폴리오가 관리자에 의해 승인처리 되었습니다.";
-
-            // 반려시 전송될 알림입니다.
-        } else if (portfolioType.equals(PortfolioType.COMPANION)) {
-            return portfolio.getMember().getNickname() + " 님의 포트폴리오가 관리자에 의해 반려처리 되었습니다.";
+    public NotificationPayloadRequest portfolioNotification(PortfolioType portfolioType, Portfolio portfolio) {
+        if (portfolioType == null || portfolio == null) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
-        return null;
+
+        // 매핑 정보에 따라 NotificationType 구하기
+        NotificationType type = NotificationType.from(portfolioType);
+        if (type == null) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        // 알림 메시지 생성
+        String nickname = portfolio.getMember().getNickname();
+        String body = type.formatMessage(nickname);
+
+        return NotificationPayloadRequest.builder()
+                .body(body)
+                .title(type.getTitle())
+                .build();
     }
 }


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->

### 흐름
1. 사용자 로그인
2. FCM 토큰 저장 API 호출
3. 알림이 전송되는 API 호출(현재는 포트폴리오 상세조회, 포트폴리오 승인 및 반려 기능)

### 포트폴리오 상세조회시 테스트 결과
<img width="727" alt="스크린샷 2025-03-14 오후 4 35 41" src="https://github.com/user-attachments/assets/f1756243-b4be-4527-a7dc-e266802dcb9a" />

### 포트폴리오 반려 혹은 승인 테스트 결과
<img width="719" alt="스크린샷 2025-03-14 오후 4 36 49" src="https://github.com/user-attachments/assets/2a3b8c5f-7f8e-4c5a-b6aa-4d7dbdee061c" />

### 사용자가 다중접속의 상태일 경우 (플랫폼이 1:N)
- 각각 WEB, IOS 의 FCM 토큰을 적용할 시 모든 기기에 알림 전송
<img width="716" alt="스크린샷 2025-03-14 오후 4 38 13" src="https://github.com/user-attachments/assets/66823afa-a07b-4f2c-9352-e9fc4b19f02c" />

TODO : PWA 프로젝트의 경우 FCM 알림설정을 ios, 안드로이드, web 각각 설정해야되는지 테스팅 해봐야 함. (현재는 WEB 푸시 알림으로만 설정)

close #148 

## ✅ 테스트
---
- [x] 수동 테스트 완료
- [ ] 테스트 코드 완료
