### PR TITLE
[기능개선][엔티티 PK] Postgres UUID 타입 지원으로 인한 엔티티 PK 수정 feat: 기존 v4 UUID 사용타입을 Postgres 내부에서 지원해주는 GenerationType.UUID로 수정 #157

### DIFF
--- a/src/main/java/com/ticketmate/backend/object/postgres/Member/Member.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/Member/Member.java
@@ -21,8 +21,8 @@ import java.util.UUID;
 public class Member extends BasePostgresEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "uuid DEFAULT uuid_generate_v4()", updatable = false, nullable = false)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
     private UUID memberId;
 
     // 소셜 로그인 시 발급되는 ID

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
@@ -28,8 +28,8 @@ import java.util.UUID;
 public class ApplicationForm extends BasePostgresEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "uuid DEFAULT uuid_generate_v4()", updatable = false, nullable = false)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
     private UUID applicationFormId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/HopeArea.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/HopeArea.java
@@ -19,8 +19,8 @@ import java.util.UUID;
 public class HopeArea extends BasePostgresEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "uuid DEFAULT uuid_generate_v4()", updatable = false, nullable = false)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
     private UUID hopeAreaId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
@@ -22,8 +22,8 @@ import java.util.UUID;
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Portfolio extends BasePostgresEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "portfolio_id", columnDefinition = "uuid DEFAULT uuid_generate_v4()", updatable = false, nullable = false)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
     private UUID portfolioId;
 
     private String portfolioDescription;  // 자기소개

--- a/src/main/java/com/ticketmate/backend/object/postgres/portfolio/PortfolioImg.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/portfolio/PortfolioImg.java
@@ -18,14 +18,13 @@ import java.util.UUID;
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class PortfolioImg extends BasePostgresEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(columnDefinition = "uuid DEFAULT uuid_generate_v4()", updatable = false, nullable = false)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
     private UUID portfolioImgId;
 
-    @Column(name = "img_name", columnDefinition = "TEXT", length = 1024)
+    @Column(columnDefinition = "TEXT", length = 1024)
     private String imgName;  // 포트폴리오 이미지 이름
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "portfolio_id")
     private Portfolio portfolio;
 }

--- a/src/main/java/com/ticketmate/backend/test/object/Ticket.java
+++ b/src/main/java/com/ticketmate/backend/test/object/Ticket.java
@@ -8,13 +8,15 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Ticket {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID ticketId;
 
     private Long quantity; // 티켓 수량
 

--- a/src/main/java/com/ticketmate/backend/test/repository/TicketRepository.java
+++ b/src/main/java/com/ticketmate/backend/test/repository/TicketRepository.java
@@ -3,5 +3,7 @@ package com.ticketmate.backend.test.repository;
 import com.ticketmate.backend.test.object.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TicketRepository extends JpaRepository<Ticket, Long> {
+import java.util.UUID;
+
+public interface TicketRepository extends JpaRepository<Ticket, UUID> {
 }

--- a/src/main/java/com/ticketmate/backend/test/service/TicketService.java
+++ b/src/main/java/com/ticketmate/backend/test/service/TicketService.java
@@ -6,6 +6,8 @@ import com.ticketmate.backend.util.redisson.RedisLockManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class TicketService {
@@ -19,7 +21,7 @@ public class TicketService {
     private final RedisLockManager redisLockManager;
 
     // 동시성 제어 없음
-    public void ticketing(Long ticketId, Long amount) {
+    public void ticketing(UUID ticketId, Long amount) {
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new IllegalArgumentException("티켓이 존재하지 않습니다."));
         ticket.decrease(amount);
@@ -27,7 +29,7 @@ public class TicketService {
     }
 
     // Redisson 기반 분산 락 사용
-    public void redissonTicketing(Long ticketId, Long amount) {
+    public void redissonTicketing(UUID ticketId, Long amount) {
         String lockKey = "ticket:" + ticketId;
 
         // 대기시간을 너무 짧게하면 tryLock 내부에서 false가 반환되어 예외가 터져 해당 스레드 로직은 작업진행이 불가능합니다.

--- a/src/test/java/com/ticketmate/backend/test/service/TicketServiceTest.java
+++ b/src/test/java/com/ticketmate/backend/test/service/TicketServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -29,7 +30,7 @@ class TicketServiceTest {
     private static final int CONCURRENT_COUNT = 100;
 
     // 테스트마다 새 티켓을 1000장으로 초기화
-    private Long TICKET_ID;
+    private UUID TICKET_ID;
 
     @BeforeEach
     public void beforeEach() {
@@ -39,7 +40,7 @@ class TicketServiceTest {
         System.out.println("1000개의 티켓 생성");
         Ticket ticket = new Ticket(1000L);
         Ticket saved = ticketRepository.saveAndFlush(ticket);
-        TICKET_ID = saved.getId();
+        TICKET_ID = saved.getTicketId();
     }
     @AfterEach
     public void afterEach() {


### PR DESCRIPTION
…타입을 Postgres 내부에서 지원해주는 GenerationType.UUID로 수정 #157

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
