### PR TITLE
20250507 #238 신청서 기반 해당 콘서트의 선예매 일반예매 필드 조회

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ko-KR"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/src/main/java/com/ticketmate/backend/object/dto/application/response/ApplicationFormFilteredResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/response/ApplicationFormFilteredResponse.java
@@ -3,6 +3,7 @@ package com.ticketmate.backend.object.dto.application.response;
 import com.ticketmate.backend.object.constants.ApplicationFormStatus;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -21,6 +22,12 @@ public class ApplicationFormFilteredResponse {
     private UUID agentId; // 대리인 PK
 
     private UUID concertId; // 콘서트 PK
+
+    private LocalDateTime performanceDate; // 공연 일자
+
+    private LocalDateTime openDate; // 티켓 오픈일
+
+    private Boolean isPreOpen; // 선예매 여부
 
     private Integer requestCount; // 매수
 

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
@@ -5,6 +5,7 @@ import com.ticketmate.backend.object.constants.ApplicationFormStatus;
 import com.ticketmate.backend.object.postgres.Member.Member;
 import com.ticketmate.backend.object.postgres.concert.Concert;
 import com.ticketmate.backend.object.postgres.concert.ConcertDate;
+import com.ticketmate.backend.object.postgres.concert.TicketOpenDate;
 import com.ticketmate.backend.object.postgres.global.BasePostgresEntity;
 import com.ticketmate.backend.util.exception.CustomException;
 import com.ticketmate.backend.util.exception.ErrorCode;
@@ -44,6 +45,9 @@ public class ApplicationForm extends BasePostgresEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private ConcertDate concertDate; // 공연일자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private TicketOpenDate ticketOpenDate; // 티켓 예매일
 
     @Column(nullable = false)
     @Builder.Default

--- a/src/main/java/com/ticketmate/backend/repository/postgres/application/ApplicationFormRepository.java
+++ b/src/main/java/com/ticketmate/backend/repository/postgres/application/ApplicationFormRepository.java
@@ -19,7 +19,7 @@ public interface ApplicationFormRepository extends JpaRepository<ApplicationForm
             and (:agentId is null or af.agent_member_id = :agentId)
             and (:concertId is null or af.concert_concert_id = :concertId)
             and (:requestCount = 0 or af.request_count = :requestCount)
-            and (:applicationFormStatus = '' or af.application_status = :applicationFormStatus)
+            and (:applicationFormStatus = '' or af.application_form_status = :applicationFormStatus)
             """,
             countQuery = """
                     select count(*)
@@ -28,7 +28,7 @@ public interface ApplicationFormRepository extends JpaRepository<ApplicationForm
                     and (:agentId is null or af.agent_member_id = :agentId)
                     and (:concertId is null or af.concert_concert_id = :concertId)
                     and (:requestCount = 0 or af.request_count = :requestCount)
-                    and (:applicationFormStatus = '' or af.application_status = :applicationFormStatus)
+                    and (:applicationFormStatus = '' or af.application_form_status = :applicationFormStatus)
                     """,
             nativeQuery = true)
     Page<ApplicationForm> filteredApplicationForm(

--- a/src/main/java/com/ticketmate/backend/service/application/ApplicationFormService.java
+++ b/src/main/java/com/ticketmate/backend/service/application/ApplicationFormService.java
@@ -115,7 +115,7 @@ public class ApplicationFormService {
         // TicketOpenDate 확인
         TicketOpenDate ticketOpenDate = null;
         if (request.getIsPreOpen() != null) { // 선예매/일반예매 오픈일이 존재하는 경우
-            log.debug("공연: {} 에 대해 선예매/일반예매 정보가 존재합니다.", concert.getConcertName());
+            log.debug("공연: {} 에 대한 신청서 요청에 선예매/일반예매 정보가 존재합니다.", concert.getConcertName());
             ticketOpenDate = ticketOpenDateRepository
                     .findByConcertConcertIdAndIsPreOpen(concert.getConcertId(), request.getIsPreOpen())
                     .orElseThrow(() -> {
@@ -146,6 +146,7 @@ public class ApplicationFormService {
                 .agent(agent)
                 .concert(concert)
                 .concertDate(concertDate)
+                .ticketOpenDate(ticketOpenDate)
                 .requestCount(request.getRequestCount())
                 .hopeAreaList(new ArrayList<>())
                 .requestDetails(request.getRequestDetails())

--- a/src/main/java/com/ticketmate/backend/service/test/TestService.java
+++ b/src/main/java/com/ticketmate/backend/service/test/TestService.java
@@ -494,6 +494,7 @@ public class TestService {
                 .agent(agent)
                 .concert(concert)
                 .concertDate(concertDate)
+                .ticketOpenDate(ticketOpenDate)
                 .requestCount(koFaker.number().numberBetween(1, ticketOpenDate.getRequestMaxCount() + 1))
                 .hopeAreaList(new ArrayList<>())
                 .requestDetails(koFaker.lorem().paragraph(2))

--- a/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
+++ b/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
@@ -79,6 +79,9 @@ public interface EntityMapper {
     @Mapping(source = "agent.memberId", target = "agentId")
     @Mapping(source = "concert.concertId", target = "concertId")
     @Mapping(source = "hopeAreaList", target = "hopeAreaResponseList")
+    @Mapping(source = "concertDate.performanceDate", target = "performanceDate")
+    @Mapping(source = "ticketOpenDate.openDate", target = "openDate")
+    @Mapping(source = "ticketOpenDate.isPreOpen", target = "isPreOpen")
     ApplicationFormFilteredResponse toApplicationFormFilteredResponse(ApplicationForm applicationForm);
   
   

--- a/src/main/java/com/ticketmate/backend/util/config/TaskExecutorConfig.java
+++ b/src/main/java/com/ticketmate/backend/util/config/TaskExecutorConfig.java
@@ -11,9 +11,9 @@ public class TaskExecutorConfig {
     @Bean("applicationTaskExecutor")
     public TaskExecutor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);
-        executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(25);
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(100);
         executor.initialize();
         return executor;
     }


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
![스크린샷 2025-05-07 오후 1 46 02](https://github.com/user-attachments/assets/5e50e617-60a4-4c69-a728-dfb36f94e4c9)
- 신청서 내역 조회시 해당 신청서가 선예매인지 일반예매인지 구분할 수 있도록 반환값을 추가했습니다


## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Application forms now display additional information: concert performance date, ticket open date, and pre-sale status.
- **Bug Fixes**
	- Corrected filtering in application form queries to use the appropriate status column.
- **Improvements**
	- Enhanced mock data and internal mappings to include ticket open date details.
	- Increased system thread pool capacity for better performance under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->