### PR TITLE
20250515 신청서 중복 신청 여부 api 추가 & isPreOpen 필드 값 수정 & 선예매/일반예매 신청 시 로직 수정

### DIFF
--- a/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
@@ -130,7 +130,7 @@ public interface AdminControllerDocs {
                     - **concertThumbNail** (MultipartFile): 콘서트 썸네일 파일 [필수]
                     - **seatingChart** (MultipartFile): 좌석 배치도 파일 [선택]
                     - **ticketReservationSite** (enum): 예매 사이트 [선택]
-                    - **concertDateRequestList** (List\\<ConcertDateRequest\\>): 공연 날짜 DTO [선택]
+                    - **concertDateRequestList** (List\\<ConcertDateRequest\\>): 공연 날짜 DTO [필수]
                     - **ticketOpenDateRequestList** (List\\<TicketOpenDateRequest\\>): 티켓 오픈일 DTO [필수]
 
                     ### ConcertDateRequest
@@ -182,7 +182,7 @@ public interface AdminControllerDocs {
                     - 티켓 오픈일은 LocalDateTime으로 "yyyy-MM-dd'T'HH:mm:ss" 형식으로 입력해야합니다
                     - 선예매/일반예매는 각각 최대 1개까지만 등록가능합니다
                     - 선예매/일반예매 데이터가 둘다 없는 경우 오류가 발생합니다
-                    - 선예매만 존재하는 경우, 일반예매만 존재하는 경우 모두 등록 가능합니다
+                    - `선예매만 존재하는 경우`, `일반예매만 존재하는 경우`, `선예매 일반예매 모두 존재하는경우` 등록 가능합니다
                     """
     )
     ResponseEntity<Void> saveConcertInfo(

--- a/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
@@ -120,7 +120,7 @@ public interface AdminControllerDocs {
     @Operation(
             summary = "공연 정보 저장",
             description = """
-                                        
+
                     이 API는 관리자 인증이 필요합니다
 
                     ### 요청 파라미터
@@ -131,51 +131,58 @@ public interface AdminControllerDocs {
                     - **seatingChart** (MultipartFile): 좌석 배치도 파일 [선택]
                     - **ticketReservationSite** (enum): 예매 사이트 [선택]
                     - **concertDateRequestList** (List\\<ConcertDateRequest\\>): 공연 날짜 DTO [선택]
-                    - **ticketOpenDateRequestList** (List\\<TicketOpenDateRequest\\>): 티켓 오픈일 DTO [선택]
-                                        
+                    - **ticketOpenDateRequestList** (List\\<TicketOpenDateRequest\\>): 티켓 오픈일 DTO [필수]
+
                     ### ConcertDateRequest
                     - **performanceDate** (LocalDateTime): 공연 일자 [필수]
                     - **session** (Integer): 공연 회차 [필수]
-                    
+
                     ### TicketOpenDateRequest
                     - **openDate** (LocalDateTime): 티켓 오픈일 [선택]
                     - **requestMaxCount** (Integer): 최대 예매 개수 [선택]
                     - **isBankTransfer** (Boolean): 무통장 입금 여부 [선택]
-                    - **isPreOpen** (Boolean): 선예매, 일반예매 여부 [필수]
+                    - **ticketOpenType** (Enum): 선예매/일반예매 타입 [필수]
                     
                     ### TicketReservationSite
                     INTERPARK_TICKET ("인터파크 티켓")
-                                    
+
                     YES24_TICKET ("예스24 티켓")
-                                    
+
                     TICKET_LINK ("티켓 링크")
-                                    
+
                     MELON_TICKET ("멜론 티켓")
-                    
+
                     COUPANG_PLAY ("쿠팡 플레이")
-                    
+
                     ETC ("기타")
-                                        
+
                     ### ConcertType
                     CONCERT ("콘서트")
-                                    
+
                     MUSICAL ("뮤지컬")
-                                    
+
                     SPORTS ("스포츠")
-                                    
+
                     CLASSIC ("클래식")
-                                    
+
                     EXHIBITIONS ("전시")
-                                    
+
                     OPERA ("오페라")
 
                     ETC ("기타")
-                                
+
+                    ### TicketOpenType
+                    PRE_OPEN ("선예매")
+                    
+                    GENERAL_OPEN("일반예매")
+                    
                     ### 유의사항
                     - `concertName`은 고유해야 합니다.
                     - 단일 회차 공연의 경우 "1"을 입력하면 됩니다.
                     - 티켓 오픈일은 LocalDateTime으로 "yyyy-MM-dd'T'HH:mm:ss" 형식으로 입력해야합니다
-
+                    - 선예매/일반예매는 각각 최대 1개까지만 등록가능합니다
+                    - 선예매/일반예매 데이터가 둘다 없는 경우 오류가 발생합니다
+                    - 선예매만 존재하는 경우, 일반예매만 존재하는 경우 모두 등록 가능합니다
                     """
     )
     ResponseEntity<Void> saveConcertInfo(
@@ -259,11 +266,11 @@ public interface AdminControllerDocs {
                     - **openDate** (LocalDateTime): 티켓 오픈일
                     - **requestMaxCount** (Integer): 최대 예매 개수
                     - **isBankTransfer** (Boolean): 무통장 입금 여부
-                    - **isPreOpen** (Boolean): 선예매, 일반예매 여부
-                                
+                    - **ticketOpenType** (Enum): 선예매, 일반예매 타입
+
                     ### 유의사항
                     - 수정이 필요한 정보만 입력하면 됩니다
-                    - 공연날짜, 티켓 오픈일은 수정 시 기존 저장 된 데이터가 모두 삭제됩니다
+                    - 공연날짜, 티켓 오픈일은 수정 시 기존 저장 된 데이터가 모두 삭제되고, 요청한 데이터로 등록됩니다.
                     """
     )
     ResponseEntity<Void> editConcertInfo(

--- a/src/main/java/com/ticketmate/backend/controller/application/ApplicationFormController.java
+++ b/src/main/java/com/ticketmate/backend/controller/application/ApplicationFormController.java
@@ -79,11 +79,11 @@ public class ApplicationFormController implements ApplicationFormControllerDocs 
     }
 
     @Override
-    @GetMapping("/duplicate")
+    @PostMapping("/duplicate")
     @LogMonitoringInvocation
     public ResponseEntity<Boolean> isDuplicateApplicationForm(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @Valid @ModelAttribute ApplicationFormDuplicateRequest request) {
+            @Valid @RequestBody ApplicationFormDuplicateRequest request) {
         Member client = customOAuth2User.getMember();
         return ResponseEntity.ok(applicationFormService.isDuplicateApplicationForm(client, request));
     }

--- a/src/main/java/com/ticketmate/backend/controller/application/ApplicationFormController.java
+++ b/src/main/java/com/ticketmate/backend/controller/application/ApplicationFormController.java
@@ -1,6 +1,7 @@
 package com.ticketmate.backend.controller.application;
 
 import com.ticketmate.backend.controller.application.docs.ApplicationFormControllerDocs;
+import com.ticketmate.backend.object.dto.application.request.ApplicationFormDuplicateRequest;
 import com.ticketmate.backend.object.dto.application.request.ApplicationFormFilteredRequest;
 import com.ticketmate.backend.object.dto.application.request.ApplicationFormRequest;
 import com.ticketmate.backend.object.dto.application.response.ApplicationFormFilteredResponse;
@@ -10,6 +11,7 @@ import com.ticketmate.backend.object.postgres.Member.Member;
 import com.ticketmate.backend.service.application.ApplicationFormService;
 import com.ticketmate.backend.util.log.LogMonitoringInvocation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -74,5 +76,15 @@ public class ApplicationFormController implements ApplicationFormControllerDocs 
                        @PathVariable(value = "application-form-id") UUID applicationFormId) {
         Member member = customOAuth2User.getMember();
         return ResponseEntity.ok(applicationFormService.approve(applicationFormId, member));
+    }
+
+    @Override
+    @GetMapping("/duplicate")
+    @LogMonitoringInvocation
+    public ResponseEntity<Boolean> isDuplicateApplicationForm(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @Valid @ModelAttribute ApplicationFormDuplicateRequest request) {
+        Member client = customOAuth2User.getMember();
+        return ResponseEntity.ok(applicationFormService.isDuplicateApplicationForm(client, request));
     }
 }

--- a/src/main/java/com/ticketmate/backend/controller/application/docs/ApplicationFormControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/application/docs/ApplicationFormControllerDocs.java
@@ -27,7 +27,7 @@ public interface ApplicationFormControllerDocs {
                     - **requestCount** (Integer): 요청한 티켓 수 [필수]
                     - **hopeAreaList** (List<HopeAreaRequest>): 희망 구역 리스트 [선택]
                     - **requestDetails** (String): 요청 사항 [선택]
-                    - **isPreOpen** (Boolean): 선예매 여부 [필수]
+                    - **ticketOpenType** (Enum): 선예매/일반예매 타입 [필수]
                     
                     ### 사용 방법
                     `요청 사항`
@@ -37,18 +37,18 @@ public interface ApplicationFormControllerDocs {
                     - requestCount: 요청할 티켓 수를 입력합니다. (최소 1, 최대 공연 티켓 수 제한)
                     - hopeAreaList: 티켓을 원하는 구역을 지정할 수 있습니다.
                     - requestDetails: 추가적인 요청 사항을 입력할 수 있습니다.
-                    - isPreOpen: 선예매 여부를 설정합니다. (`true`일 경우 선예매, `false`일 경우 일반 예매)
+                    - ticketOpenType: 선예매/일반예매 타입을 설정합니다.
                     
                     ### 유의사항
                     - 대리인(`agentId`)과 의뢰인(`clientId`)은 반드시 올바른 회원 유형이어야 합니다.
                     - 요청된 티켓 수(`requestCount`)는 공연의 티켓 예매 가능 범위 내여야 합니다.
                     - 중복된 신청서는 허용되지 않으며, 이미 대리인에게 신청서를 제출한 경우 오류가 발생합니다.
                     - 희망 구역은 선택 사항으로, 제공된 공연 구역에 맞춰 유효한 구역을 선택해야 합니다.
-                    - 선예매와 일반 예매 구분은 `isPreOpen`으로 결정됩니다.
+                    - 선예매와 일반 예매 구분은 `ticketOpenType`으로 결정됩니다.
                     
                     `TicketOpenDate`
-                    - 선예매(`isPreOpen=true`)일 경우, 해당 공연의 선예매 정보가 있어야 합니다.
-                    - 일반 예매(`isPreOpen=false`)일 경우, 일반 예매 정보가 있어야 합니다.
+                    - 선예매(`ticketOpenType=PRE_OPEN`)일 경우, 해당 공연의 선예매 정보가 있어야 합니다.
+                    - 일반 예매(`ticketOpenType=GENERAL_OPEN`)일 경우, 일반 예매 정보가 있어야 합니다.
                     
                     ### 주의사항
                     - 대리인이 아닌 회원이 대리인으로 지정되면 `INVALID_MEMBER_TYPE` 오류가 발생합니다.
@@ -131,7 +131,7 @@ public interface ApplicationFormControllerDocs {
                     ### 요청 파라미터
                     - **applicationFormId** (UUID): 거절할 신청서 PK [필수]
                     - **applicationFormRejectedType** (String): 거절사유 [필수]
-                    - **otherMemo** (String): 거절사유 '기타'일 시 작성할 메모                  
+                    - **otherMemo** (String): 거절사유 '기타'일 시 작성할 메모
                     
                     ### ApplicationRejectedType
                     

--- a/src/main/java/com/ticketmate/backend/controller/application/docs/ApplicationFormControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/application/docs/ApplicationFormControllerDocs.java
@@ -1,5 +1,6 @@
 package com.ticketmate.backend.controller.application.docs;
 
+import com.ticketmate.backend.object.dto.application.request.ApplicationFormDuplicateRequest;
 import com.ticketmate.backend.object.dto.application.request.ApplicationFormFilteredRequest;
 import com.ticketmate.backend.object.dto.application.request.ApplicationFormRequest;
 import com.ticketmate.backend.object.dto.application.response.ApplicationFormFilteredResponse;
@@ -16,9 +17,9 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 작성",
             description = """
-
+                    
                     이 API는 인증이 필요합니다
-
+                    
                     ### 요청 파라미터
                     - **agentId** (UUID): 대리인 PK [필수]
                     - **concertId** (UUID): 콘서트 PK [필수]
@@ -27,7 +28,7 @@ public interface ApplicationFormControllerDocs {
                     - **hopeAreaList** (List<HopeAreaRequest>): 희망 구역 리스트 [선택]
                     - **requestDetails** (String): 요청 사항 [선택]
                     - **isPreOpen** (Boolean): 선예매 여부 [필수]
-    
+                    
                     ### 사용 방법
                     `요청 사항`
                     - agentId: 대리인으로 지정된 회원의 ID를 입력합니다.
@@ -37,18 +38,18 @@ public interface ApplicationFormControllerDocs {
                     - hopeAreaList: 티켓을 원하는 구역을 지정할 수 있습니다.
                     - requestDetails: 추가적인 요청 사항을 입력할 수 있습니다.
                     - isPreOpen: 선예매 여부를 설정합니다. (`true`일 경우 선예매, `false`일 경우 일반 예매)
-    
+                    
                     ### 유의사항
                     - 대리인(`agentId`)과 의뢰인(`clientId`)은 반드시 올바른 회원 유형이어야 합니다.
                     - 요청된 티켓 수(`requestCount`)는 공연의 티켓 예매 가능 범위 내여야 합니다.
                     - 중복된 신청서는 허용되지 않으며, 이미 대리인에게 신청서를 제출한 경우 오류가 발생합니다.
                     - 희망 구역은 선택 사항으로, 제공된 공연 구역에 맞춰 유효한 구역을 선택해야 합니다.
                     - 선예매와 일반 예매 구분은 `isPreOpen`으로 결정됩니다.
-    
+                    
                     `TicketOpenDate`
                     - 선예매(`isPreOpen=true`)일 경우, 해당 공연의 선예매 정보가 있어야 합니다.
                     - 일반 예매(`isPreOpen=false`)일 경우, 일반 예매 정보가 있어야 합니다.
-    
+                    
                     ### 주의사항
                     - 대리인이 아닌 회원이 대리인으로 지정되면 `INVALID_MEMBER_TYPE` 오류가 발생합니다.
                     - 이미 신청서를 제출한 경우, `DUPLICATE_APPLICATION_FROM_REQUEST` 오류가 발생합니다.
@@ -61,9 +62,9 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 필터링 조회",
             description = """
-
+                    
                     이 API는 인증이 필요합니다.
-
+                    
                     ### 요청 파라미터
                     - **clientId** (UUID): 의뢰인 PK [선택]
                     - **agentId** (UUID): 대리인 PK [선택]
@@ -74,7 +75,7 @@ public interface ApplicationFormControllerDocs {
                     - **pageSize** (Integer): 한 페이지 당 항목 수 [선택]
                     - **sortField** (String): 정렬할 필드 [선택]
                     - **sortDirection** (String): 정렬 방향 [선택]
-
+                    
                     ### 사용 방법
                     `필터링 파라미터`
                     - clientId: 의뢰인이 작성한 신청서를 반환합니다
@@ -82,20 +83,20 @@ public interface ApplicationFormControllerDocs {
                     - concertId: 특정 공연에 작성된 신청서를 반환합니다
                     - requestCount: 요청 매수에 따른 신청서를 반환합니다
                     - applicationStatus: 신청서 상태에 따른 신청서를 반환합니다
-
+                    
                     `정렬 조건`
                     - sortField: created_date(기본값), request_count
                     - sortDirection: DESC(기본값), ASC
-
+                    
                     `ApplicationStatus`
                     PENDING("대기")
-                
+                    
                     APPROVED("승인")
-                
+                    
                     REJECTED("거절")
-                
+                    
                     EXPIRED("만료")
-
+                    
                     ### 유의사항
                     - clientId, agentId, concertId, requestCount, applicationStatus 는 요청하지 않을 경우 필터링 조건에 적용되지 않습니다
                     - sortField와 sortDirection은 해당하는 문자열만 입력 가능합니다.
@@ -108,12 +109,12 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 상세 조회",
             description = """
-
+                    
                     이 API는 인증이 필요합니다
-
+                    
                     ### 요청 파라미터
                     - **applicationFormId** (UUID): 조회할 신청서 PK [필수]
-
+                    
                     ### 유의사항
                     """
     )
@@ -124,9 +125,9 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 거절",
             description = """
-
+                    
                     이 API는 인증이 필요합니다
-
+                    
                     ### 요청 파라미터
                     - **applicationFormId** (UUID): 거절할 신청서 PK [필수]
                     - **applicationFormRejectedType** (String): 거절사유 [필수]
@@ -141,12 +142,12 @@ public interface ApplicationFormControllerDocs {
                     SCHEDULE_UNAVAILABLE("티켓팅 일정이 안됨")
                     
                     OTHER("기타")
-
+                    
                     ### 유의사항
                     - 해당 API는 대리인만 사용 가능합니다.
                     - 거절사유가 OTHER('기타') 일 시 otherMemo는 2자 이상이여야 합니다.
                     - 거절 사유가 OTHER이 아닐 시에는 otherMemo는 공백처리해서 주시면 됩니다. 
-                                            
+                    
                     """
     )
     void reject(
@@ -156,9 +157,9 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 수락",
             description = """
-
+                    
                     이 API는 인증이 필요합니다
-
+                    
                     ### 요청 파라미터
                     - **applicationFormId** (UUID): 수락할 신청서 PK [필수]
                     
@@ -172,4 +173,29 @@ public interface ApplicationFormControllerDocs {
     )
     ResponseEntity<String> approve(
             CustomOAuth2User customOAuth2User, UUID applicationFormId);
+
+    @Operation(
+            summary = "신청서 중복 확인",
+            description = """
+                    
+                    이 API는 인증이 필요합니다
+                    
+                    ### 요청 파라미터
+                    - **agentId** (UUID): 대리인 PK [필수]
+                    - **concertId** (UUID): 공연 PK [필수]
+                    - **ticketOpenType** (Enum): 선예매/일반예매 타입 [필수]
+                    
+                    ### TicketOpenType
+                    GENERAL_OPEN("일반예매")
+                    PRE_OPEN("선예매")
+
+                    ### 유의사항
+                    - 의뢰인이 이미 특정 공연, 특정 대리인에 대해 선예매/일반예매로 신청서를 작성했는지 여부를 반환합니다
+                    - 이미 작성하여 중복되는 경우 true를 반환합니다
+                    """
+    )
+    ResponseEntity<Boolean> isDuplicateApplicationForm(
+            CustomOAuth2User customOAuth2User,
+            ApplicationFormDuplicateRequest request
+    );
 }

--- a/src/main/java/com/ticketmate/backend/controller/application/docs/ApplicationFormControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/application/docs/ApplicationFormControllerDocs.java
@@ -17,42 +17,34 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 작성",
             description = """
+                    의뢰인이 대리인에게 티켓팅을 요청하기 위한 신청서를 작성합니다.
                     
-                    이 API는 인증이 필요합니다
+                    ### 인증 필요
+                    - 의뢰인(CLIENT) 타입의 사용자만 요청 가능합니다.
                     
-                    ### 요청 파라미터
+                    ### 요청 본문
                     - **agentId** (UUID): 대리인 PK [필수]
-                    - **concertId** (UUID): 콘서트 PK [필수]
-                    - **performanceDate** (LocalDateTime): 공연 일자 [필수]
-                    - **requestCount** (Integer): 요청한 티켓 수 [필수]
-                    - **hopeAreaList** (List<HopeAreaRequest>): 희망 구역 리스트 [선택]
-                    - **requestDetails** (String): 요청 사항 [선택]
-                    - **ticketOpenType** (Enum): 선예매/일반예매 타입 [필수]
+                    - **concertId** (UUID): 공연 PK [필수]
+                    - **applicationFormDetailRequestList** (배열): 신청 공연 회차 목록 [최소 1개 이상 필수]
+                      - **performanceDate** (String): 공연 일시 (yyyy-MM-dd'T'HH:mm:ss 형식) [필수]
+                      - **requestCount** (Integer): 요청 매수 [필수, 최소 1장]
+                      - **hopeAreaList** (배열): 희망 구역 목록
+                        - **priority** (Integer): 희망 구역 우선순위 [필수, 1~10 사이 값]
+                        - **location** (String): 희망 구역 위치명 [필수, 예: "A구역"]
+                        - **price** (Long): 희망 구역 가격 [필수, 0원 이상]
+                      - **requestDetails** (String): 요청 사항
+                    - **ticketOpenType** (Enum): 선예매/일반예매 구분 [필수]
+                      - GENERAL_OPEN: 일반예매
+                      - PRE_OPEN: 선예매
                     
-                    ### 사용 방법
-                    `요청 사항`
-                    - agentId: 대리인으로 지정된 회원의 ID를 입력합니다.
-                    - concertId: 신청할 콘서트의 ID를 입력합니다.
-                    - performanceDate: 신청할 공연의 일시를 입력합니다.
-                    - requestCount: 요청할 티켓 수를 입력합니다. (최소 1, 최대 공연 티켓 수 제한)
-                    - hopeAreaList: 티켓을 원하는 구역을 지정할 수 있습니다.
-                    - requestDetails: 추가적인 요청 사항을 입력할 수 있습니다.
-                    - ticketOpenType: 선예매/일반예매 타입을 설정합니다.
-                    
-                    ### 유의사항
-                    - 대리인(`agentId`)과 의뢰인(`clientId`)은 반드시 올바른 회원 유형이어야 합니다.
-                    - 요청된 티켓 수(`requestCount`)는 공연의 티켓 예매 가능 범위 내여야 합니다.
-                    - 중복된 신청서는 허용되지 않으며, 이미 대리인에게 신청서를 제출한 경우 오류가 발생합니다.
-                    - 희망 구역은 선택 사항으로, 제공된 공연 구역에 맞춰 유효한 구역을 선택해야 합니다.
-                    - 선예매와 일반 예매 구분은 `ticketOpenType`으로 결정됩니다.
-                    
-                    `TicketOpenDate`
-                    - 선예매(`ticketOpenType=PRE_OPEN`)일 경우, 해당 공연의 선예매 정보가 있어야 합니다.
-                    - 일반 예매(`ticketOpenType=GENERAL_OPEN`)일 경우, 일반 예매 정보가 있어야 합니다.
-                    
-                    ### 주의사항
-                    - 대리인이 아닌 회원이 대리인으로 지정되면 `INVALID_MEMBER_TYPE` 오류가 발생합니다.
-                    - 이미 신청서를 제출한 경우, `DUPLICATE_APPLICATION_FROM_REQUEST` 오류가 발생합니다.
+                    ### 주요 오류 코드
+                    - MEMBER_NOT_FOUND: 존재하지 않는 회원
+                    - INVALID_MEMBER_TYPE: 부적절한 회원 타입 (대리인이 아님)
+                    - CONCERT_NOT_FOUND: 존재하지 않는 공연
+                    - DUPLICATE_APPLICATION_FROM_REQUEST: 이미 해당 공연에 대한 신청서 존재
+                    - APPLICATION_FORM_DETAIL_REQUIRED: 공연 회차 정보 누락
+                    - TICKET_OPEN_DATE_NOT_FOUND: 티켓 오픈일 정보 없음
+                    - TICKET_REQUEST_COUNT_EXCEED: 요청 매수 초과
                     """
     )
     ResponseEntity<Void> saveApplicationForm(
@@ -60,46 +52,42 @@ public interface ApplicationFormControllerDocs {
             ApplicationFormRequest request);
 
     @Operation(
-            summary = "대리 티켓팅 신청서 필터링 조회",
+            summary = "신청서 필터링 조회",
             description = """
+                    다양한 조건으로 신청서 목록을 필터링하여 조회합니다.
                     
-                    이 API는 인증이 필요합니다.
+                    ### 인증 필요
                     
                     ### 요청 파라미터
-                    - **clientId** (UUID): 의뢰인 PK [선택]
-                    - **agentId** (UUID): 대리인 PK [선택]
-                    - **concertId** (UUID): 공연 PK [선택]
-                    - **requestCount** (Integer): 매수 [선택]
-                    - **applicationStatus** (Enum): 신청서 상태 [선택]
-                    - **pageNumber** (Integer): 요청 페이지 번호 [선택]
-                    - **pageSize** (Integer): 한 페이지 당 항목 수 [선택]
-                    - **sortField** (String): 정렬할 필드 [선택]
-                    - **sortDirection** (String): 정렬 방향 [선택]
-                    
-                    ### 사용 방법
-                    `필터링 파라미터`
-                    - clientId: 의뢰인이 작성한 신청서를 반환합니다
-                    - agentId: 대리인이 받은 신청서를 반환합니다
-                    - concertId: 특정 공연에 작성된 신청서를 반환합니다
-                    - requestCount: 요청 매수에 따른 신청서를 반환합니다
-                    - applicationStatus: 신청서 상태에 따른 신청서를 반환합니다
-                    
-                    `정렬 조건`
-                    - sortField: created_date(기본값), request_count
-                    - sortDirection: DESC(기본값), ASC
-                    
-                    `ApplicationStatus`
-                    PENDING("대기")
-                    
-                    APPROVED("승인")
-                    
-                    REJECTED("거절")
-                    
-                    EXPIRED("만료")
-                    
-                    ### 유의사항
-                    - clientId, agentId, concertId, requestCount, applicationStatus 는 요청하지 않을 경우 필터링 조건에 적용되지 않습니다
-                    - sortField와 sortDirection은 해당하는 문자열만 입력 가능합니다.
+                    - **clientId** (UUID): 의뢰인 PK [선택, 생략 시 모든 의뢰인]
+                    - **agentId** (UUID): 대리인 PK [선택, 생략 시 모든 대리인]
+                    - **concertId** (UUID): 공연 PK [선택, 생략 시 모든 공연]
+                    - **applicationFormStatus** (Enum): 신청서 상태 [선택]
+                      - PENDING: 대기 중
+                      - APPROVED: 승인됨
+                      - REJECTED: 거절됨
+                      - COMPLETED: 완료됨
+                    - **pageNumber** (Integer): 페이지 번호 [선택, 기본값 0]
+                    - **pageSize** (Integer): 페이지 크기 [선택, 기본값 30]
+                    - **sortField** (String): 정렬 기준 [선택, 기본값 created_date]
+                      - created_date: 생성일 기준
+                      - total_request_count: 요청 매수 기준
+                    - **sortDirection** (String): 정렬 방향 [선택, 기본값 DESC]
+                      - ASC: 오름차순
+                      - DESC: 내림차순
+                      
+                    ### 반환 데이터
+                    - Page<ApplicationFormFilteredResponse>: 페이지네이션된 신청서 목록
+                      - content: 신청서 정보 배열
+                      - totalElements: 전체 항목 수
+                      - totalPages: 전체 페이지 수
+                      - number: 현재 페이지 번호
+                      - size: 페이지 크기
+                      
+                    ### 주요 오류 코드
+                    - INVALID_MEMBER_TYPE: 부적절한 회원 타입
+                    - MEMBER_NOT_FOUND: 존재하지 않는 회원
+                    - CONCERT_NOT_FOUND: 존재하지 않는 공연
                     """
     )
     ResponseEntity<Page<ApplicationFormFilteredResponse>> filteredApplicationForm(
@@ -109,13 +97,35 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 상세 조회",
             description = """
+                    특정 신청서의 상세 정보를 조회합니다.
                     
-                    이 API는 인증이 필요합니다
+                    ### 인증 필요
                     
-                    ### 요청 파라미터
+                    ### 경로 변수
                     - **applicationFormId** (UUID): 조회할 신청서 PK [필수]
                     
-                    ### 유의사항
+                    ### 반환 데이터
+                    - ApplicationFormFilteredResponse: 신청서 상세 정보
+                      - applicationFormId: 신청서 ID
+                      - clientId: 의뢰인 ID
+                      - agentId: 대리인 ID
+                      - concertId: 공연 ID
+                      - openDate: 티켓 오픈일
+                      - applicationFormDetailResponseList: 신청 회차 정보 목록
+                        - performanceDate: 공연 일시
+                        - session: 회차
+                        - requestCount: 요청 매수
+                        - hopeAreaResponseList: 희망 구역 목록
+                          - priority: 우선순위
+                          - location: 위치
+                          - price: 가격
+                        - requirement: 요청 사항
+                      - totalRequestCount: 전체 요청 매수
+                      - applicationFormStatus: 신청서 상태
+                      - ticketOpenType: 선예매/일반예매 구분
+                      
+                    ### 주요 오류 코드
+                    - APPLICATION_FORM_NOT_FOUND: 신청서를 찾을 수 없음
                     """
     )
     ResponseEntity<ApplicationFormFilteredResponse> applicationFormInfo(
@@ -125,13 +135,22 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 거절",
             description = """
+                    대리인이 의뢰인의 티켓팅 신청서를 거절합니다.
                     
-                    이 API는 인증이 필요합니다
+                    ### 인증 필요
+                    - 대리인(AGENT) 타입의 사용자만 요청 가능합니다.
                     
-                    ### 요청 파라미터
-                    - **applicationFormId** (UUID): 거절할 신청서 PK [필수]
-                    - **applicationFormRejectedType** (String): 거절사유 [필수]
-                    - **otherMemo** (String): 거절사유 '기타'일 시 작성할 메모
+                    ### 경로 변수
+                    - **application-form-id** (UUID): 거절할 신청서 PK [필수]
+                    
+                    ### 요청 본문
+                    - **applicationFormRejectedType** (Enum): 거절 사유 [필수]
+                    - **otherMemo** (String): 기타 사유인 경우 상세 메모 [기타 사유인 경우 필수, 2자 이상]
+                    
+                    ### 주요 오류 코드
+                    - INVALID_MEMBER_TYPE: 부적절한 회원 타입 (대리인이 아님)
+                    - APPLICATION_FORM_NOT_FOUND: 신청서를 찾을 수 없음
+                    - INVALID_MEMO_REQUEST: 유효하지 않은 메모 (기타 사유인데 메모가 2자 미만)
                     
                     ### ApplicationRejectedType
                     
@@ -146,8 +165,7 @@ public interface ApplicationFormControllerDocs {
                     ### 유의사항
                     - 해당 API는 대리인만 사용 가능합니다.
                     - 거절사유가 OTHER('기타') 일 시 otherMemo는 2자 이상이여야 합니다.
-                    - 거절 사유가 OTHER이 아닐 시에는 otherMemo는 공백처리해서 주시면 됩니다. 
-                    
+                    - 거절 사유가 OTHER이 아닐 시에는 otherMemo는 공백처리해서 주시면 됩니다.
                     """
     )
     void reject(
@@ -157,11 +175,23 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "대리 티켓팅 신청서 수락",
             description = """
+                    대리인이 의뢰인의 티켓팅 신청서를 승인합니다.
+                    승인 시 의뢰인과 대리인 간의 채팅방이 자동으로 생성됩니다.
                     
-                    이 API는 인증이 필요합니다
+                    ### 인증 필요
+                    - 대리인(AGENT) 타입의 사용자만 요청 가능합니다.
                     
-                    ### 요청 파라미터
-                    - **applicationFormId** (UUID): 수락할 신청서 PK [필수]
+                    ### 경로 변수
+                    - **application-form-id** (UUID): 승인할 신청서 PK [필수]
+                    
+                    ### 반환 데이터
+                    - String: 생성된 채팅방 ID
+                    
+                    ### 주요 오류 코드
+                    - INVALID_MEMBER_TYPE: 부적절한 회원 타입 (대리인이 아님)
+                    - APPLICATION_FORM_NOT_FOUND: 신청서를 찾을 수 없음
+                    - INVALID_APPLICATION_FORM_STATUS: 유효하지 않은 신청서 상태 (대기 상태가 아님)
+                    - ALREADY_APPROVED_APPLICATION_FROM: 이미 다른 신청서가 승인된 상태
                     
                     ### 유의사항
                     - 해당 API는 대리인만 사용 가능합니다.
@@ -177,21 +207,23 @@ public interface ApplicationFormControllerDocs {
     @Operation(
             summary = "신청서 중복 확인",
             description = """
+                    이미 의뢰인이 대리인에게 해당 공연(선예매/일반예매 구분)에 대한 신청서를 작성했는지 확인합니다.
                     
-                    이 API는 인증이 필요합니다
+                    ### 인증 필요
                     
                     ### 요청 파라미터
                     - **agentId** (UUID): 대리인 PK [필수]
                     - **concertId** (UUID): 공연 PK [필수]
                     - **ticketOpenType** (Enum): 선예매/일반예매 타입 [필수]
+                      - GENERAL_OPEN: 일반예매
+                      - PRE_OPEN: 선예매
                     
-                    ### TicketOpenType
-                    GENERAL_OPEN("일반예매")
-                    PRE_OPEN("선예매")
-
-                    ### 유의사항
-                    - 의뢰인이 이미 특정 공연, 특정 대리인에 대해 선예매/일반예매로 신청서를 작성했는지 여부를 반환합니다
-                    - 이미 작성하여 중복되는 경우 true를 반환합니다
+                    ### 반환 데이터
+                    - Boolean: 중복 여부 (true: 중복, false: 중복 아님)
+                    
+                    ### 활용 방법
+                    - 의뢰인이 신청서 작성 전 중복 확인용으로 사용
+                    - 중복(true)인 경우 이미 신청한 신청서가 있으므로 추가 신청 불필요
                     """
     )
     ResponseEntity<Boolean> isDuplicateApplicationForm(

--- a/src/main/java/com/ticketmate/backend/controller/concert/docs/ConcertControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/concert/docs/ConcertControllerDocs.java
@@ -68,34 +68,35 @@ public interface ConcertControllerDocs {
     @Operation(
             summary = "공연 정보 상세조회",
             description = """
-
+                    이 API는 특정 공연 ID를 통해 공연의 상세 정보를 조회합니다.
+                    인증이 필요합니다.
+            
                     ### 요청 파라미터
-                    - **concertId** (UUID): 공연 PK [필수]
-    
+                    - **concertId** (UUID): 조회할 공연의 고유 ID (PathVariable)
+            
                     ### 응답 데이터
-                    - **concertName** (String): 공연명
-                    - **concertHallName** (String): 공연장 이름 (없을 경우 null)
-                    - **concertThumbnailUrl** (String): 공연 썸네일 이미지 URL
-                    - **seatingChartUrl** (String): 좌석 배치도 URL (없을 경우 null)
-                    - **concertType** (String): 공연 카테고리 (없을 경우 null)
-                    - **startDate** (LocalDateTime): 공연 시작 일자 (가장 빠른 공연 날짜)
-                    - **endDate** (LocalDateTime): 공연 종료 일자 (가장 늦은 공연 날짜)
-                    - **preOpenDate** (LocalDateTime): 선예매 오픈일 (없을 경우 null)
-                    - **preOpenRequestMaxCount** (Integer): 선예매 최대 예매 매수 (없을 경우 null)
-                    - **preOpenIsBankTransfer** (Boolean): 선예매 무통장 입금 가능 여부 (없을 경우 null)
-                    - **generalOpenDate** (LocalDateTime): 일반 예매 오픈일 (없을 경우 null)
-                    - **generalOpenRequestMaxCount** (Integer): 일반 예매 최대 예매 매수 (없을 경우 null)
-                    - **generalOpenIsBankTransfer** (Boolean): 일반 예매 무통장 입금 가능 여부 (없을 경우 null)
-                    - **ticketReservationSite** (String): 예매처 (없을 경우 null)
-    
-                    ### 사용 방법
-                    - concertId를 통해 특정 공연의 상세 정보를 조회합니다.
-                    - 공연 날짜는 여러 개일 수 있으며, startDate는 가장 빠른 날짜, endDate는 가장 늦은 날짜를 반환합니다.
-                    - 선예매와 일반 예매 정보는 각각 최대 1개만 존재하며, 해당 정보가 없으면 관련 필드가 모두 null로 반환됩니다.
-    
-                    ### 유의사항
-                    - concertId가 유효하지 않으면 CONCERT_NOT_FOUND 에러가 발생합니다.
-                    - 선예매 정보가 존재하면 일반 예매 정보도 반드시 존재합니다. 일반 예매만 단독으로 존재할 수 있습니다.
+                    - **concertId** (UUID): 공연 ID
+                    - **concertName** (String): 공연 이름
+                    - **concertHallName** (String): 공연장 이름
+                    - **concertType** (String): 공연 유형 (예: CONCERT, MUSICAL 등)
+                    - **concertDates** (List): 공연 날짜 리스트
+                        - **startDateTime** (String): 공연 시작 시간 (yyyy-MM-dd HH:mm:ss)
+                        - **endDateTime** (String): 공연 종료 시간 (yyyy-MM-dd HH:mm:ss)
+                    - **ticketOpenDates** (List): 예매 오픈 날짜 리스트
+                        - **ticketOpenDatetime** (String): 예매 오픈 시간
+                        - **ticketReservationSite** (String): 예매처 (예: INTERPARK_TICKET 등)
+            
+                    ### 사용 방법 & 유의 사항
+                    - 이 API는 로그인된 사용자만 호출할 수 있습니다.
+                    - 공연 ID는 UUID 형식이어야 하며, 올바르지 않으면 오류가 발생합니다.
+                    - 반환되는 날짜 및 시간 정보는 모두 ISO 8601 형식의 문자열입니다.
+                    - 공연에 따라 `ticketOpenDates` 또는 `concertDates` 정보가 없을 수 있습니다.
+            
+                    ### 예외 처리
+                    - **404 NOT_FOUND**: 해당 공연 ID에 대한 공연 정보가 존재하지 않을 경우
+                        - message: "존재하지 않는 공연입니다."
+                    - **400 BAD_REQUEST**: UUID 형식이 아닌 concertId를 요청 시
+                        - message: "잘못된 요청입니다."
                     """
     )
     ResponseEntity<ConcertInfoResponse> getConcertInfo(

--- a/src/main/java/com/ticketmate/backend/object/constants/TicketOpenType.java
+++ b/src/main/java/com/ticketmate/backend/object/constants/TicketOpenType.java
@@ -1,0 +1,14 @@
+package com.ticketmate.backend.object.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TicketOpenType {
+
+    GENERAL_OPEN("일반예매"),
+    PRE_OPEN("선예매"),;
+
+    private final String description;
+}

--- a/src/main/java/com/ticketmate/backend/object/dto/admin/request/ConcertInfoRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/admin/request/ConcertInfoRequest.java
@@ -4,6 +4,7 @@ import com.ticketmate.backend.object.constants.ConcertType;
 import com.ticketmate.backend.object.constants.TicketReservationSite;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -37,7 +38,9 @@ public class ConcertInfoRequest {
     @Schema(defaultValue = "INTERPARK_TICKET")
     private TicketReservationSite ticketReservationSite; // 예매 사이트
 
+    @NotEmpty(message = "공연 날짜를 입력하세요.")
     private List<ConcertDateRequest> concertDateRequestList; // 공연 날짜 DTO
 
+    @NotEmpty(message = "티켓 오픈일 정보를 입력하세요")
     private List<TicketOpenDateRequest> ticketOpenDateRequestList; // 티켓 오픈일 DTO
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/admin/request/TicketOpenDateRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/admin/request/TicketOpenDateRequest.java
@@ -1,7 +1,7 @@
 package com.ticketmate.backend.object.dto.admin.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import io.swagger.v3.oas.annotations.media.Schema;
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -26,7 +26,6 @@ public class TicketOpenDateRequest {
 
     private Boolean isBankTransfer; // 무통장 입금 여부
 
-    @NotNull(message = "선예매 여부를 선택하세요. 일반예매 정보는 필수로 포함되어야합니다.")
-    @Schema(defaultValue = "false")
-    private Boolean isPreOpen; // 선예매, 일반예매 여부
+    @NotNull(message = "선예매/일반예매 타입을 입력하세요")
+    private TicketOpenType ticketOpenType; // 선예매, 일반예매 타입
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormDetailRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormDetailRequest.java
@@ -1,0 +1,37 @@
+package com.ticketmate.backend.object.dto.application.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ApplicationFormDetailRequest {
+
+    @NotNull(message = "공열일자를 입력하세요")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Schema(defaultValue = "2025-02-11T20:00:00")
+    private LocalDateTime performanceDate; // 공연일자
+
+    @NotNull(message = "티켓 요청 매수를 입력해주세요")
+    @Min(value = 1)
+    @Max(value = Integer.MAX_VALUE)
+    @Schema(defaultValue = "1")
+    private Integer requestCount; // 요청매수
+
+    private List<HopeAreaRequest> hopeAreaList = new ArrayList<>(); // 희망구역 리스트
+
+    @Schema(defaultValue = "꼭 잡아주세요...!!")
+    private String requestDetails; // 요청사항
+}

--- a/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormDuplicateRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormDuplicateRequest.java
@@ -1,0 +1,21 @@
+package com.ticketmate.backend.object.dto.application.request;
+
+import com.ticketmate.backend.object.constants.TicketOpenType;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.UUID;
+
+@ToString
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ApplicationFormDuplicateRequest {
+    @NotNull(message = "대리인 PK 값을 입력하세요")
+    private UUID agentId;
+    @NotNull(message = "공연 PK 값을 입력하세요")
+    private UUID concertId;
+    @NotNull(message = "선예매/일반예매 타입을 입력하세요")
+    private TicketOpenType ticketOpenType;
+}

--- a/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormFilteredRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormFilteredRequest.java
@@ -30,9 +30,6 @@ public class ApplicationFormFilteredRequest {
 
     private UUID concertId; // 공연 PK
 
-    @Schema(defaultValue = "1")
-    private Integer requestCount; // 매수
-
     @Schema(defaultValue = "PENDING")
     private ApplicationFormStatus applicationFormStatus; // 신청서 상태
 

--- a/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormRequest.java
@@ -1,6 +1,7 @@
 package com.ticketmate.backend.object.dto.application.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -42,7 +43,6 @@ public class ApplicationFormRequest {
     @Schema(defaultValue = "꼭 잡아주세요...!!")
     private String requestDetails; // 요청사항
 
-    @NotNull(message = "선예매 여부를 입력해주세요")
-    @Schema(defaultValue = "false")
-    private Boolean isPreOpen; // 선예매 여부
+    @NotNull(message = "선예매/일반예매 타입을 입력해주세요")
+    private TicketOpenType ticketOpenType; // 선예매 여부
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormRequest.java
@@ -1,15 +1,10 @@
 package com.ticketmate.backend.object.dto.application.request;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.ticketmate.backend.object.constants.TicketOpenType;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -27,21 +22,8 @@ public class ApplicationFormRequest {
     @NotNull(message = "콘서트 PK 값을 입력해주세요")
     private UUID concertId; // 콘서트 PK
 
-    @NotNull(message = "공연일자를 입력해주세요")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Schema(defaultValue = "2025-02-11T20:00:00")
-    private LocalDateTime performanceDate; // 공연일자
-
-    @NotNull(message = "티켓 요청 매수를 입력해주세요")
-    @Min(value = 1)
-    @Max(value = Integer.MAX_VALUE)
-    @Schema(defaultValue = "1")
-    private Integer requestCount; // 요청매수
-
-    private List<HopeAreaRequest> hopeAreaList = new ArrayList<>();
-
-    @Schema(defaultValue = "꼭 잡아주세요...!!")
-    private String requestDetails; // 요청사항
+    @NotEmpty(message = "공연일자 JSON을 입력하세요")
+    private List<ApplicationFormDetailRequest> applicationFormDetailRequestList; // 신청서 공연회차 List
 
     @NotNull(message = "선예매/일반예매 타입을 입력해주세요")
     private TicketOpenType ticketOpenType; // 선예매 여부

--- a/src/main/java/com/ticketmate/backend/object/dto/application/response/ApplicationFormDetailResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/response/ApplicationFormDetailResponse.java
@@ -1,0 +1,25 @@
+package com.ticketmate.backend.object.dto.application.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ApplicationFormDetailResponse {
+
+    private LocalDateTime performanceDate; // 공연 일자
+
+    private Integer session; // 회차
+
+    private Integer requestCount; // 요청 매수
+
+    private List<HopeAreaResponse> hopeAreaResponseList; // 희망 구역 리스트
+
+    private String requirement; // 요청 사항
+}

--- a/src/main/java/com/ticketmate/backend/object/dto/application/response/ApplicationFormFilteredResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/response/ApplicationFormFilteredResponse.java
@@ -24,17 +24,13 @@ public class ApplicationFormFilteredResponse {
 
     private UUID concertId; // 콘서트 PK
 
-    private LocalDateTime performanceDate; // 공연 일자
+    private LocalDateTime openDate; // 티켓 예매일
 
-    private LocalDateTime openDate; // 티켓 오픈일
+    private List<ApplicationFormDetailResponse> applicationFormDetailResponseList; // 신청서 세부사항 리스트
 
-    private TicketOpenType ticketOpenType; // 선예매/일반예매 타입
-
-    private Integer requestCount; // 매수
-
-    private List<HopeAreaResponse> hopeAreaResponseList; // 희망구역 리스트
-
-    private String requestDetails; // 요청사항
+    private Integer totalRequestCount; // 전체 요청 매수
 
     private ApplicationFormStatus applicationFormStatus; // 신청서 상태
+
+    private TicketOpenType ticketOpenType; // 선예매/일반예매 타입
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/application/response/ApplicationFormFilteredResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/response/ApplicationFormFilteredResponse.java
@@ -1,6 +1,7 @@
 package com.ticketmate.backend.object.dto.application.response;
 
 import com.ticketmate.backend.object.constants.ApplicationFormStatus;
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -27,7 +28,7 @@ public class ApplicationFormFilteredResponse {
 
     private LocalDateTime openDate; // 티켓 오픈일
 
-    private Boolean isPreOpen; // 선예매 여부
+    private TicketOpenType ticketOpenType; // 선예매/일반예매 타입
 
     private Integer requestCount; // 매수
 

--- a/src/main/java/com/ticketmate/backend/object/dto/application/response/HopeAreaResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/response/HopeAreaResponse.java
@@ -10,9 +10,9 @@ import lombok.*;
 @Builder
 public class HopeAreaResponse {
 
-    private Integer priority; // 순위
+    private Integer priority; // 우선 순위 (1~10)
 
-    private String location; // 위치
+    private String location; // 위치 (예: A구역, B구역)
 
     private Long price; // 가격
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/concert/response/ConcertDateInfoResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/concert/response/ConcertDateInfoResponse.java
@@ -1,0 +1,16 @@
+package com.ticketmate.backend.object.dto.concert.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ConcertDateInfoResponse {
+    private LocalDateTime performanceDate; // 공연일자
+    private Integer session; // 회차
+}

--- a/src/main/java/com/ticketmate/backend/object/dto/concert/response/ConcertInfoResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/concert/response/ConcertInfoResponse.java
@@ -4,7 +4,7 @@ import com.ticketmate.backend.object.constants.ConcertType;
 import com.ticketmate.backend.object.constants.TicketReservationSite;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 @ToString
 @AllArgsConstructor
@@ -18,13 +18,7 @@ public class ConcertInfoResponse {
     private String concertThumbnailUrl; // 공연 썸네일 이미지 url
     private String seatingChartUrl; // 좌석 배치도 url
     private ConcertType concertType; // 공연 카테고리
-    private LocalDateTime startDate; // 공연 시작 일자
-    private LocalDateTime endDate; // 공연 종료 일자
-    private LocalDateTime preOpenDate; // 선예매 오픈일
-    private Integer preOpenRequestMaxCount; // 선예매 최대 예매 매수
-    private Boolean preOpenIsBankTransfer; // 선예매 무통장 입금 가능 여부
-    private LocalDateTime generalOpenDate; // 일반 예매 오픈일
-    private Integer generalOpenRequestMaxCount; // 일반 예매 최대 예매 매수
-    private Boolean generalOpenIsBankTransfer; // 일반 예매 무통장 입금 가능 여부
+    private List<ConcertDateInfoResponse> concertDateInfoResponseList; // 공연일자 List
+    private List<TicketOpenDateInfoResponse> ticketOpenDateInfoResponses; // 티켓 오픈일 List
     private TicketReservationSite ticketReservationSite; // 예매처
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/concert/response/TicketOpenDateInfoResponse.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/concert/response/TicketOpenDateInfoResponse.java
@@ -1,0 +1,19 @@
+package com.ticketmate.backend.object.dto.concert.response;
+
+import com.ticketmate.backend.object.constants.TicketOpenType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class TicketOpenDateInfoResponse {
+    private LocalDateTime openDate; // 티켓 오픈일
+    private Integer requestMaxCount; // 최대 예매 매수
+    private Boolean isBankTransfer; // 무통장 입금 여부
+    private TicketOpenType ticketOpenType; // 선예매, 일반예매 여부
+}

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
@@ -49,7 +49,7 @@ public class ApplicationForm extends BasePostgresEntity {
 
     @Column(nullable = false)
     @Builder.Default
-    private Integer totalRequestCount = 0; // 전체 요청 매수 (모든 공연일차 총 매수)
+    private Integer totalRequestCount = 0; // 전체 요청 매수 (모든 공연일자 총 매수)
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
@@ -2,6 +2,7 @@ package com.ticketmate.backend.object.postgres.application;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.ticketmate.backend.object.constants.ApplicationFormStatus;
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.postgres.Member.Member;
 import com.ticketmate.backend.object.postgres.concert.Concert;
 import com.ticketmate.backend.object.postgres.concert.ConcertDate;
@@ -63,6 +64,9 @@ public class ApplicationForm extends BasePostgresEntity {
     @Column(nullable = false)
     private ApplicationFormStatus applicationFormStatus; // 신청서 상태
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TicketOpenType ticketOpenType; // 선예매, 일반예매 구분
 
     private static final int HOPE_AREAS_MAX_SIZE = 10;
 

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationForm.java
@@ -5,11 +5,8 @@ import com.ticketmate.backend.object.constants.ApplicationFormStatus;
 import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.postgres.Member.Member;
 import com.ticketmate.backend.object.postgres.concert.Concert;
-import com.ticketmate.backend.object.postgres.concert.ConcertDate;
 import com.ticketmate.backend.object.postgres.concert.TicketOpenDate;
 import com.ticketmate.backend.object.postgres.global.BasePostgresEntity;
-import com.ticketmate.backend.util.exception.CustomException;
-import com.ticketmate.backend.util.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -45,20 +42,14 @@ public class ApplicationForm extends BasePostgresEntity {
     private Concert concert; // 공연
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private ConcertDate concertDate; // 공연일자
-
-    @ManyToOne(fetch = FetchType.LAZY)
     private TicketOpenDate ticketOpenDate; // 티켓 예매일
+
+    @OneToMany(mappedBy = "applicationForm", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ApplicationFormDetail> applicationFormDetailList = new ArrayList<>();
 
     @Column(nullable = false)
     @Builder.Default
-    private Integer requestCount = 1; // 매수
-
-    @OneToMany(mappedBy = "applicationForm", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<HopeArea> hopeAreaList = new ArrayList<>();
-
-    @Column(columnDefinition = "TEXT")
-    private String requestDetails; // 요청사항
+    private Integer totalRequestCount = 0; // 전체 요청 매수 (모든 공연일차 총 매수)
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -68,21 +59,9 @@ public class ApplicationForm extends BasePostgresEntity {
     @Column(nullable = false)
     private TicketOpenType ticketOpenType; // 선예매, 일반예매 구분
 
-    private static final int HOPE_AREAS_MAX_SIZE = 10;
-
-    // 희망구역 설정
-    public void addHopeArea(HopeArea hopeArea) {
-        if (hopeAreaList.size() >= HOPE_AREAS_MAX_SIZE) {
-            log.error("희망구역은 최대 {}개까지만 설정 가능합니다. 현재 희망구역 개수: {}",
-                    HOPE_AREAS_MAX_SIZE, hopeAreaList.size());
-            throw new CustomException(ErrorCode.HOPE_AREAS_SIZE_EXCEED);
-        }
-        if (hopeAreaList.stream().anyMatch(area ->
-                area.getPriority().equals(hopeArea.getPriority()))) {
-            log.error("해당 순위는 이미 설정되어 있습니다. 요청된 순위: {}", hopeArea.getPriority());
-            throw new CustomException(ErrorCode.PRIORITY_ALREADY_EXISTS);
-        }
-        hopeAreaList.add(hopeArea);
-        hopeArea.setApplicationForm(this);
+    // 신청서 세부사항 추가 메서드
+    public void addApplicationFormDetail(ApplicationFormDetail applicationFormDetail) {
+        applicationFormDetailList.add(applicationFormDetail);
+        applicationFormDetail.setApplicationForm(this);
     }
 }

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationFormDetail.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationFormDetail.java
@@ -43,7 +43,7 @@ public class ApplicationFormDetail extends BasePostgresEntity {
     @Column(columnDefinition = "TEXT")
     private String requirement; // 요청 사항
 
-    @OneToMany(mappedBy = "applicationFormDatail", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "applicationFormDetail", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<HopeArea> hopeAreaList = new ArrayList<>();
 
     private static final int HOPE_AREA_MAX_SIZE = 10;

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationFormDetail.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/ApplicationFormDetail.java
@@ -1,0 +1,63 @@
+package com.ticketmate.backend.object.postgres.application;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ticketmate.backend.object.postgres.concert.ConcertDate;
+import com.ticketmate.backend.object.postgres.global.BasePostgresEntity;
+import com.ticketmate.backend.util.exception.CustomException;
+import com.ticketmate.backend.util.exception.ErrorCode;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(callSuper = true)
+@Slf4j
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class ApplicationFormDetail extends BasePostgresEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false, nullable = false)
+    private UUID applicationFormDetailId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ApplicationForm applicationForm; // 신청서
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ConcertDate concertDate; // 공연일자
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer requestCount = 1; // 요청 매수
+
+    @Column(columnDefinition = "TEXT")
+    private String requirement; // 요청 사항
+
+    @OneToMany(mappedBy = "applicationFormDatail", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<HopeArea> hopeAreaList = new ArrayList<>();
+
+    private static final int HOPE_AREA_MAX_SIZE = 10;
+
+    // 희망구역 설정 메서드
+    public void addHopeArea(HopeArea hopeArea) {
+        if (hopeAreaList.size() >= HOPE_AREA_MAX_SIZE) {
+            throw new CustomException(ErrorCode.HOPE_AREAS_SIZE_EXCEED);
+        }
+        if (hopeAreaList.stream().anyMatch(area ->
+                area.getPriority().equals(hopeArea.getPriority()))) {
+            throw new CustomException(ErrorCode.PRIORITY_ALREADY_EXISTS);
+        }
+        hopeAreaList.add(hopeArea);
+        hopeArea.setApplicationFormDetail(this);
+    }
+}

--- a/src/main/java/com/ticketmate/backend/object/postgres/application/HopeArea.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/application/HopeArea.java
@@ -24,7 +24,7 @@ public class HopeArea extends BasePostgresEntity {
     private UUID hopeAreaId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private ApplicationForm applicationForm; // 신청서
+    private ApplicationFormDetail applicationFormDetail;
 
     @Column(nullable = false)
     private Integer priority; // 순위 (1~10)

--- a/src/main/java/com/ticketmate/backend/object/postgres/concert/TicketOpenDate.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/concert/TicketOpenDate.java
@@ -1,6 +1,7 @@
 package com.ticketmate.backend.object.postgres.concert;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.postgres.global.BasePostgresEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -33,6 +34,7 @@ public class TicketOpenDate extends BasePostgresEntity {
 
     private Boolean isBankTransfer; // 무통장 입금 여부
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Boolean isPreOpen; // 선예매, 일반예매 여부
+    private TicketOpenType ticketOpenType; // 선예매, 일반예매 여부
 }

--- a/src/main/java/com/ticketmate/backend/repository/postgres/application/ApplicationFormRepository.java
+++ b/src/main/java/com/ticketmate/backend/repository/postgres/application/ApplicationFormRepository.java
@@ -1,5 +1,6 @@
 package com.ticketmate.backend.repository.postgres.application;
 
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.postgres.application.ApplicationForm;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -40,8 +41,8 @@ public interface ApplicationFormRepository extends JpaRepository<ApplicationForm
             Pageable pageable
     );
 
-    // 이미 의뢰인이 대리인에게 해당 공연 신청서를 보냈는지 검증
-    boolean existsByClient_MemberIdAndAgent_MemberIdAndConcert_ConcertId(UUID clientId, UUID agentId, UUID concertId);
+    // 이미 의뢰인이 대리인에게 해당 공연에 대한 선예매/일반예매 신청서를 보냈는지 검증
+    boolean existsByClientMemberIdAndAgentMemberIdAndConcertConcertIdAndTicketOpenType(UUID clientID, UUID agentId, UUID concertId, TicketOpenType ticketOpenType);
 
-    List<ApplicationForm> findAllByConcert_ConcertIdAndClient_MemberId(UUID concertId, UUID clientId);
+    List<ApplicationForm> findAllByConcertConcertIdAndClientMemberId(UUID concertId, UUID clientId);
 }

--- a/src/main/java/com/ticketmate/backend/repository/postgres/application/ApplicationFormRepository.java
+++ b/src/main/java/com/ticketmate/backend/repository/postgres/application/ApplicationFormRepository.java
@@ -4,15 +4,32 @@ import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.postgres.application.ApplicationForm;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ApplicationFormRepository extends JpaRepository<ApplicationForm, UUID> {
 
+    // fetch join 을 통한 성능 최적화
+    @EntityGraph(attributePaths = {
+            "applicationFormDetailList",
+            "applicationFormDetailList.hopeAreaList",
+            "client",
+            "agent",
+            "concert",
+            "ticketOpenDate"
+    })
+    Optional<ApplicationForm> findWithDetailByApplicationFormId(@Param("applicationFormId") UUID applicationFormId);
+
+    @EntityGraph(attributePaths = {
+            "applicationFormDetailList",
+            "applicationFormDetailList.hopeAreaList"
+    })
     @Query(value = """
             select *
             from application_form af
@@ -36,7 +53,6 @@ public interface ApplicationFormRepository extends JpaRepository<ApplicationForm
             @Param("clientId") UUID clientId,
             @Param("agentId") UUID agentId,
             @Param("concertId") UUID concertId,
-            @Param("requestCount") Integer requestCount,
             @Param("applicationFormStatus") String applicationFormStatus,
             Pageable pageable
     );

--- a/src/main/java/com/ticketmate/backend/repository/postgres/concert/ConcertRepositoryImpl.java
+++ b/src/main/java/com/ticketmate/backend/repository/postgres/concert/ConcertRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ticketmate.backend.object.constants.ConcertType;
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.constants.TicketReservationSite;
 import com.ticketmate.backend.object.dto.concert.response.ConcertFilteredResponse;
 import com.ticketmate.backend.object.postgres.concert.QConcert;
@@ -73,7 +74,7 @@ public class ConcertRepositoryImpl implements ConcertRepositoryCustom {
                                 LocalDateTime.class,
                                 "min({0})",
                                 new CaseBuilder()
-                                        .when(ticketOpenDate.isPreOpen.eq(true))
+                                        .when(ticketOpenDate.ticketOpenType.eq(TicketOpenType.PRE_OPEN))
                                         .then(ticketOpenDate.openDate)
                                         .otherwise((LocalDateTime) null)
                         ).as("ticketPreOpenDate"),
@@ -81,7 +82,7 @@ public class ConcertRepositoryImpl implements ConcertRepositoryCustom {
                         Expressions.booleanTemplate(
                                 "bool_or({0})",
                                 new CaseBuilder()
-                                        .when(ticketOpenDate.isPreOpen.eq(true))
+                                        .when(ticketOpenDate.ticketOpenType.eq(TicketOpenType.PRE_OPEN))
                                         .then((ComparableExpression<Boolean>) ticketOpenDate.isBankTransfer)
                                         .otherwise((Boolean) null)
                         ).as("preOpenBankTransfer"),
@@ -90,7 +91,7 @@ public class ConcertRepositoryImpl implements ConcertRepositoryCustom {
                                 LocalDateTime.class,
                                 "min({0})",
                                 new CaseBuilder()
-                                        .when(ticketOpenDate.isPreOpen.eq(false))
+                                        .when(ticketOpenDate.ticketOpenType.eq(TicketOpenType.GENERAL_OPEN))
                                         .then(ticketOpenDate.openDate)
                                         .otherwise((LocalDateTime) null)
                         ).as("ticketGeneralOpenDate"),
@@ -98,7 +99,7 @@ public class ConcertRepositoryImpl implements ConcertRepositoryCustom {
                         Expressions.booleanTemplate(
                                 "bool_or({0})",
                                 new CaseBuilder()
-                                        .when(ticketOpenDate.isPreOpen.eq(false))
+                                        .when(ticketOpenDate.ticketOpenType.eq(TicketOpenType.GENERAL_OPEN))
                                         .then((ComparableExpression<Boolean>) ticketOpenDate.isBankTransfer)
                                         .otherwise((Boolean) null)
                         ).as("generalOpenBankTransfer"),

--- a/src/main/java/com/ticketmate/backend/repository/postgres/concert/TicketOpenDateRepository.java
+++ b/src/main/java/com/ticketmate/backend/repository/postgres/concert/TicketOpenDateRepository.java
@@ -1,5 +1,6 @@
 package com.ticketmate.backend.repository.postgres.concert;
 
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.postgres.concert.TicketOpenDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,7 +12,7 @@ public interface TicketOpenDateRepository extends JpaRepository<TicketOpenDate, 
 
     List<TicketOpenDate> findAllByConcertConcertId(UUID concertId);
 
-    Optional<TicketOpenDate> findByConcertConcertIdAndIsPreOpen(UUID concertId, Boolean isPreOpen);
+    Optional<TicketOpenDate> findByConcertConcertIdAndTicketOpenType(UUID concertId, TicketOpenType ticketOpenType);
 
     void deleteAllByConcertConcertId(UUID concertId);
 }

--- a/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
+++ b/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
@@ -113,33 +113,29 @@ public class AdminService {
         concertRepository.save(concert);
 
         // 6. 공연 날짜 저장
-        if (request.getConcertDateRequestList() != null && !request.getConcertDateRequestList().isEmpty()) {
-            List<ConcertDate> concertDateList = request.getConcertDateRequestList().stream()
-                    .map(dateRequest -> ConcertDate.builder()
-                            .concert(concert)
-                            .performanceDate(dateRequest.getPerformanceDate())
-                            .session(dateRequest.getSession())
-                            .build()
-                    )
-                    .collect(Collectors.toList());
-            concertDateRepository.saveAll(concertDateList);
-        }
+        List<ConcertDate> concertDateList = request.getConcertDateRequestList().stream()
+                .map(dateRequest -> ConcertDate.builder()
+                        .concert(concert)
+                        .performanceDate(dateRequest.getPerformanceDate())
+                        .session(dateRequest.getSession())
+                        .build()
+                )
+                .collect(Collectors.toList());
+        concertDateRepository.saveAll(concertDateList);
 
         // 7. 티켓 오픈일 검증 및 저장
-        if (request.getTicketOpenDateRequestList() != null && !request.getTicketOpenDateRequestList().isEmpty()) { // 티켓 오픈일이 입력된 경우
-            // 티켓 오픈일 요청에 선예매/일반예매 데이터가 최소 한개 이상 존재하는지 검증
-            validateTicketOpenDateList(request.getTicketOpenDateRequestList());
-            List<TicketOpenDate> ticketOpenDateList = request.getTicketOpenDateRequestList().stream()
-                    .map(ticketOpenDateRequest -> TicketOpenDate.builder()
-                            .concert(concert)
-                            .openDate(ticketOpenDateRequest.getOpenDate())
-                            .requestMaxCount(ticketOpenDateRequest.getRequestMaxCount())
-                            .isBankTransfer(ticketOpenDateRequest.getIsBankTransfer())
-                            .ticketOpenType(ticketOpenDateRequest.getTicketOpenType())
-                            .build())
-                    .collect(Collectors.toList());
-            ticketOpenDateRepository.saveAll(ticketOpenDateList);
-        }
+        // 티켓 오픈일 요청에 선예매/일반예매 데이터가 최소 한개 이상 존재하는지 검증
+        validateTicketOpenDateList(request.getTicketOpenDateRequestList());
+        List<TicketOpenDate> ticketOpenDateList = request.getTicketOpenDateRequestList().stream()
+                .map(ticketOpenDateRequest -> TicketOpenDate.builder()
+                        .concert(concert)
+                        .openDate(ticketOpenDateRequest.getOpenDate())
+                        .requestMaxCount(ticketOpenDateRequest.getRequestMaxCount())
+                        .isBankTransfer(ticketOpenDateRequest.getIsBankTransfer())
+                        .ticketOpenType(ticketOpenDateRequest.getTicketOpenType())
+                        .build())
+                .collect(Collectors.toList());
+        ticketOpenDateRepository.saveAll(ticketOpenDateList);
         log.debug("공연 정보 저장 성공: {}", request.getConcertName());
     }
 

--- a/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
+++ b/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
@@ -3,6 +3,7 @@ package com.ticketmate.backend.service.admin;
 import com.ticketmate.backend.object.constants.City;
 import com.ticketmate.backend.object.constants.MemberType;
 import com.ticketmate.backend.object.constants.PortfolioType;
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.dto.admin.request.*;
 import com.ticketmate.backend.object.dto.admin.response.ConcertHallFilteredAdminResponse;
 import com.ticketmate.backend.object.dto.admin.response.PortfolioForAdminResponse;
@@ -136,7 +137,7 @@ public class AdminService {
                             .openDate(ticketOpenDateRequest.getOpenDate())
                             .requestMaxCount(ticketOpenDateRequest.getRequestMaxCount())
                             .isBankTransfer(ticketOpenDateRequest.getIsBankTransfer())
-                            .isPreOpen(ticketOpenDateRequest.getIsPreOpen())
+                            .ticketOpenType(ticketOpenDateRequest.getTicketOpenType())
                             .build())
                     .collect(Collectors.toList());
             ticketOpenDateRepository.saveAll(ticketOpenDateList);
@@ -240,7 +241,7 @@ public class AdminService {
                             .openDate(ticketOpenDateRequest.getOpenDate())
                             .requestMaxCount(ticketOpenDateRequest.getRequestMaxCount())
                             .isBankTransfer(ticketOpenDateRequest.getIsBankTransfer())
-                            .isPreOpen(ticketOpenDateRequest.getIsPreOpen())
+                            .ticketOpenType(ticketOpenDateRequest.getTicketOpenType())
                             .build())
                     .collect(Collectors.toList());
             ticketOpenDateRepository.saveAll(ticketOpenDateList);
@@ -264,7 +265,8 @@ public class AdminService {
 
         // 일반 예매 필수 검증
         boolean hasGeneralOpen = ticketOpenDateRequestList.stream()
-                .anyMatch(date -> !date.getIsPreOpen());
+                .anyMatch(request ->
+                        request.getTicketOpenType().equals(TicketOpenType.GENERAL_OPEN));
         if (!hasGeneralOpen) {
             log.error("일반 예매 날짜는 필수로 포함되어야합니다");
             throw new CustomException(ErrorCode.GENERAL_TICKET_OPEN_DATE_REQUIRED);

--- a/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
+++ b/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
@@ -37,7 +37,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.servlet.View;
 
 import java.util.List;
 import java.util.UUID;
@@ -60,7 +59,6 @@ public class AdminService {
     private final EntityMapper entityMapper;
     private final FcmService fcmService;
     private final NotificationUtil notificationUtil;
-    private final View error;
     @Value("${cloud.aws.s3.path.portfolio.cloud-front-domain}")
     private String portFolioDomain;
 
@@ -264,21 +262,19 @@ public class AdminService {
     private void validateTicketOpenDateList(List<TicketOpenDateRequest> ticketOpenDateRequestList) {
 
         // 일반 예매, 선 예매는 각각 최대 한개씩 존재 가능
-        int preOpenRequestCount = ticketOpenDateRequestList.stream()
+        long preOpenRequestCount = ticketOpenDateRequestList.stream()
                 .filter(ticketOpenDateRequest ->
                         ticketOpenDateRequest.getTicketOpenType().equals(TicketOpenType.PRE_OPEN))
-                .toList()
-                .size();
+                .count();
         if (preOpenRequestCount > 1) {
             log.error("선예매 오픈일 데이터가 여러 개 요청되었습니다. 요청된 선예매 데이터 개수: {}개", preOpenRequestCount);
             throw new CustomException(ErrorCode.PRE_OPEN_COUNT_EXCEED);
         }
 
-        int generalOpenRequestCount = ticketOpenDateRequestList.stream()
+        long generalOpenRequestCount = ticketOpenDateRequestList.stream()
                 .filter(ticketOpenDateRequest ->
                         ticketOpenDateRequest.getTicketOpenType().equals(TicketOpenType.GENERAL_OPEN))
-                .toList()
-                .size();
+                .count();
         if (generalOpenRequestCount > 1) {
             log.error("일반 예매 오픈일 데이터가 여러 개 요청되었습니다. 요청된 일반예매 데이터 개수: {}개", generalOpenRequestCount);
             throw new CustomException(ErrorCode.GENERAL_OPEN_COUNT_EXCEED);

--- a/src/main/java/com/ticketmate/backend/service/application/ApplicationFormService.java
+++ b/src/main/java/com/ticketmate/backend/service/application/ApplicationFormService.java
@@ -38,14 +38,12 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import static com.ticketmate.backend.object.constants.MemberType.AGENT;
 import static com.ticketmate.backend.object.constants.MemberType.CLIENT;
 import static com.ticketmate.backend.util.common.CommonUtil.enumToString;
-import static com.ticketmate.backend.util.common.CommonUtil.null2ZeroInt;
 
 @Service
 @Slf4j
@@ -162,11 +160,9 @@ public class ApplicationFormService {
                     .concertDate(concertDate)
                     .requestCount(detailRequest.getRequestCount())
                     .requirement(detailRequest.getRequestDetails())
-                    .hopeAreaList(new ArrayList<>())
                     .build();
 
             // 신청서 세부사항 희망구역 설정
-            List<HopeArea> hopeAreaList = new ArrayList<>();
             for (HopeAreaRequest hopeAreaRequest : detailRequest.getHopeAreaList()) {
                 HopeArea hopeArea = HopeArea.builder()
                         .priority(hopeAreaRequest.getPriority())
@@ -196,7 +192,6 @@ public class ApplicationFormService {
      * @param request clientId 의뢰인 PK
      *                agentId 대리인 PK
      *                concertId 콘서트 PK
-     *                requestCount 매수
      *                applicationStatus 신청서 상태
      *                pageNumber 요청 페이지 번호 (기본 0)
      *                pageSize 한 페이지 당 항목 수 (기본 30)
@@ -210,7 +205,6 @@ public class ApplicationFormService {
         UUID agentId = request.getAgentId();
         UUID concertId = request.getConcertId();
         String applicationStatus = enumToString(request.getApplicationFormStatus());
-        int requestCount = null2ZeroInt(request.getRequestCount());
 
         // clientId가 입력된 경우 의뢰인 검증
         if (clientId != null) {
@@ -259,7 +253,6 @@ public class ApplicationFormService {
                         clientId,
                         agentId,
                         concertId,
-                        requestCount,
                         applicationStatus,
                         pageable
                 );
@@ -277,8 +270,8 @@ public class ApplicationFormService {
     @Transactional(readOnly = true)
     public ApplicationFormFilteredResponse getApplicationFormInfo(UUID applicationFormId) {
 
-        // 데이터베이스 조회
-        ApplicationForm applicationForm = applicationFormRepository.findById(applicationFormId)
+        // 데이터베이스 조회 (fetch join 방식)
+        ApplicationForm applicationForm = applicationFormRepository.findWithDetailByApplicationFormId(applicationFormId)
                 .orElseThrow(() -> {
                     log.error("대리 티켓팅 신청서를 찾을 수 없습니다.");
                     return new CustomException(ErrorCode.APPLICATION_FORM_NOT_FOUND);

--- a/src/main/java/com/ticketmate/backend/service/application/ApplicationFormService.java
+++ b/src/main/java/com/ticketmate/backend/service/application/ApplicationFormService.java
@@ -163,13 +163,15 @@ public class ApplicationFormService {
                     .build();
 
             // 신청서 세부사항 희망구역 설정
-            for (HopeAreaRequest hopeAreaRequest : detailRequest.getHopeAreaList()) {
-                HopeArea hopeArea = HopeArea.builder()
-                        .priority(hopeAreaRequest.getPriority())
-                        .location(hopeAreaRequest.getLocation())
-                        .price(hopeAreaRequest.getPrice())
-                        .build();
-                applicationFormDetail.addHopeArea(hopeArea);
+            if (!CommonUtil.nullOrEmpty(detailRequest.getHopeAreaList())) {
+                for (HopeAreaRequest hopeAreaRequest : detailRequest.getHopeAreaList()) {
+                    HopeArea hopeArea = HopeArea.builder()
+                            .priority(hopeAreaRequest.getPriority())
+                            .location(hopeAreaRequest.getLocation())
+                            .price(hopeAreaRequest.getPrice())
+                            .build();
+                    applicationFormDetail.addHopeArea(hopeArea);
+                }
             }
 
             // ApplicationForm에 ApplicationFormDetail 추가

--- a/src/main/java/com/ticketmate/backend/service/concert/ConcertService.java
+++ b/src/main/java/com/ticketmate/backend/service/concert/ConcertService.java
@@ -4,8 +4,10 @@ import com.ticketmate.backend.object.constants.ConcertType;
 import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.constants.TicketReservationSite;
 import com.ticketmate.backend.object.dto.concert.request.ConcertFilteredRequest;
+import com.ticketmate.backend.object.dto.concert.response.ConcertDateInfoResponse;
 import com.ticketmate.backend.object.dto.concert.response.ConcertFilteredResponse;
 import com.ticketmate.backend.object.dto.concert.response.ConcertInfoResponse;
+import com.ticketmate.backend.object.dto.concert.response.TicketOpenDateInfoResponse;
 import com.ticketmate.backend.object.postgres.concert.Concert;
 import com.ticketmate.backend.object.postgres.concert.ConcertDate;
 import com.ticketmate.backend.object.postgres.concert.TicketOpenDate;
@@ -14,6 +16,7 @@ import com.ticketmate.backend.repository.postgres.concert.ConcertRepository;
 import com.ticketmate.backend.repository.postgres.concert.ConcertRepositoryImpl;
 import com.ticketmate.backend.repository.postgres.concert.TicketOpenDateRepository;
 import com.ticketmate.backend.util.common.CommonUtil;
+import com.ticketmate.backend.util.common.EntityMapper;
 import com.ticketmate.backend.util.exception.CustomException;
 import com.ticketmate.backend.util.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +28,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -41,6 +43,7 @@ public class ConcertService {
     private final ConcertDateRepository concertDateRepository;
     private final TicketOpenDateRepository ticketOpenDateRepository;
     private final ConcertRepositoryImpl concertRepositoryImpl;
+    private final EntityMapper entityMapper;
 
     /**
      * 공연 필터링 조회 로직
@@ -90,7 +93,7 @@ public class ConcertService {
     @Transactional(readOnly = true)
     public ConcertInfoResponse getConcertInfo(UUID concertId) {
 
-        // 1. DB에서 공연정보, 공연일자, 티켓오픈일 조회
+        // DB에서 공연정보, 공연일자, 티켓오픈일 조회
         Concert concert = concertRepository.findById(concertId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CONCERT_NOT_FOUND));
 
@@ -112,13 +115,13 @@ public class ConcertService {
             seatingChartUrl = concert.getSeatingChartUrl();
         }
 
-        // 1-1. 비동기적으로 관련 데이터 멀티스레드 조회
+        // 비동기적으로 관련 데이터 멀티스레드 조회
         CompletableFuture<List<ConcertDate>> concertDateListFuture = CompletableFuture
                 .supplyAsync(() -> concertDateRepository.findAllByConcertConcertId(concert.getConcertId()));
         CompletableFuture<List<TicketOpenDate>> ticketOpenDateListFuture = CompletableFuture
                 .supplyAsync(() -> ticketOpenDateRepository.findAllByConcertConcertId(concert.getConcertId()));
 
-        // 1-2. 데이터 조회 완료 대기
+        // 데이터 조회 완료 대기
         List<ConcertDate> concertDateList;
         List<TicketOpenDate> ticketOpenDateList;
         try {
@@ -129,20 +132,34 @@ public class ConcertService {
             throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
 
-        // 2. 공연 시작일/종료일 계산
-        LocalDateTime startDate = concertDateList.stream()
-                .map(ConcertDate::getPerformanceDate)
-                .filter(Objects::nonNull)
-                .min(LocalDateTime::compareTo)
-                .orElse(null);
-        LocalDateTime endDate = concertDateList.stream()
-                .map(ConcertDate::getPerformanceDate)
-                .filter(Objects::nonNull)
-                .max(LocalDateTime::compareTo)
-                .orElse(null);
+        // 공연날짜 DTO List 생성
+        List<ConcertDateInfoResponse> concertDateInfoResponseList = entityMapper.toConcertDateInfoResponseList(concertDateList);
 
+        // 티켓 오픈일 검증
+        validateTicketOpenDateList(ticketOpenDateList);
 
-        // 3. 사전/일반 예매 정보 추출
+        // 티켓 오픈일 DTO List 생성
+        List<TicketOpenDateInfoResponse> ticketOpenDateInfoResponseList = entityMapper.toTicketOpenDateInfoResponseList(ticketOpenDateList);
+
+        // 4. 반환값
+        return ConcertInfoResponse.builder()
+                .concertName(concert.getConcertName())
+                .concertHallName(concertHallName)
+                .concertThumbnailUrl(concert.getConcertThumbnailUrl())
+                .seatingChartUrl(seatingChartUrl)
+                .concertType(concert.getConcertType())
+                .concertDateInfoResponseList(concertDateInfoResponseList)
+                .ticketOpenDateInfoResponses(ticketOpenDateInfoResponseList)
+                .ticketReservationSite(ticketReservationSite)
+                .build();
+    }
+
+    /**
+     * 티켓 오픈일 검증
+     * 1. 선예매/일반예매 모두 없는경우
+     * 2. 선예매/일반예매가 각각 한개를 초과하여 등록된 경우
+     */
+    private void validateTicketOpenDateList(List<TicketOpenDate> ticketOpenDateList) {
         // Enum 키를 위한 EnumMap 사용
         Map<TicketOpenType, List<TicketOpenDate>> openDateListByType = new EnumMap<>(TicketOpenType.class);
 
@@ -175,34 +192,5 @@ public class ConcertService {
             log.error("일반예매 오픈일이 여러 개 등록되어있습니다. 등록된 일반예매 오픈일 정보 개수: {}개", generalOpenDateList.size());
             throw new CustomException(ErrorCode.GENERAL_OPEN_COUNT_EXCEED);
         }
-
-        // 검증된 리스트에서 첫 번째 항목만 사용하므로 간결하게 처리
-        TicketOpenDate preOpen = preOpenDateList.isEmpty() ? null : preOpenDateList.get(0);
-        LocalDateTime preOpenDate = preOpen != null ? preOpen.getOpenDate() : null;
-        Integer preOpenRequestMaxCount = preOpen != null ? preOpen.getRequestMaxCount() : null;
-        Boolean preOpenIsBankTransfer = preOpen != null ? preOpen.getIsBankTransfer() : null;
-
-        TicketOpenDate generalOpen = generalOpenDateList.isEmpty() ? null : generalOpenDateList.get(0);
-        LocalDateTime generalOpenDate = generalOpen != null ? generalOpen.getOpenDate() : null;
-        Integer generalOpenRequestMaxCount = generalOpen != null ? generalOpen.getRequestMaxCount() : null;
-        Boolean generalOpenIsBankTransfer = generalOpen != null ? generalOpen.getIsBankTransfer() : null;
-
-        // 4. 반환값
-        return ConcertInfoResponse.builder()
-                .concertName(concert.getConcertName())
-                .concertHallName(concertHallName)
-                .concertThumbnailUrl(concert.getConcertThumbnailUrl())
-                .seatingChartUrl(seatingChartUrl)
-                .concertType(concert.getConcertType())
-                .startDate(startDate)
-                .endDate(endDate)
-                .preOpenDate(preOpenDate)
-                .preOpenRequestMaxCount(preOpenRequestMaxCount)
-                .preOpenIsBankTransfer(preOpenIsBankTransfer)
-                .generalOpenDate(generalOpenDate)
-                .generalOpenRequestMaxCount(generalOpenRequestMaxCount)
-                .generalOpenIsBankTransfer(generalOpenIsBankTransfer)
-                .ticketReservationSite(ticketReservationSite)
-                .build();
     }
 }

--- a/src/main/java/com/ticketmate/backend/service/concert/ConcertService.java
+++ b/src/main/java/com/ticketmate/backend/service/concert/ConcertService.java
@@ -1,6 +1,7 @@
 package com.ticketmate.backend.service.concert;
 
 import com.ticketmate.backend.object.constants.ConcertType;
+import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.constants.TicketReservationSite;
 import com.ticketmate.backend.object.dto.concert.request.ConcertFilteredRequest;
 import com.ticketmate.backend.object.dto.concert.response.ConcertFilteredResponse;
@@ -12,7 +13,6 @@ import com.ticketmate.backend.repository.postgres.concert.ConcertDateRepository;
 import com.ticketmate.backend.repository.postgres.concert.ConcertRepository;
 import com.ticketmate.backend.repository.postgres.concert.ConcertRepositoryImpl;
 import com.ticketmate.backend.repository.postgres.concert.TicketOpenDateRepository;
-import com.ticketmate.backend.util.common.EntityMapper;
 import com.ticketmate.backend.util.exception.CustomException;
 import com.ticketmate.backend.util.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,6 @@ public class ConcertService {
     private final ConcertDateRepository concertDateRepository;
     private final TicketOpenDateRepository ticketOpenDateRepository;
     private final ConcertRepositoryImpl concertRepositoryImpl;
-    private final EntityMapper entityMapper;
 
     /**
      * 공연 필터링 조회 로직
@@ -146,7 +145,8 @@ public class ConcertService {
 
         // 3. 사전/일반 예매 정보 추출
         TicketOpenDate preOpen = ticketOpenDateList.stream()
-                .filter(TicketOpenDate::getIsPreOpen)
+                .filter(ticketOpenDate ->
+                        ticketOpenDate.getTicketOpenType().equals(TicketOpenType.PRE_OPEN))
                 .findFirst()
                 .orElse(null);
         LocalDateTime preOpenDate = preOpen != null ? preOpen.getOpenDate() : null;
@@ -154,7 +154,8 @@ public class ConcertService {
         Boolean preOpenIsBankTransfer = preOpen != null ? preOpen.getIsBankTransfer() : null;
 
         TicketOpenDate generalOpen = ticketOpenDateList.stream()
-                .filter(ticket -> !ticket.getIsPreOpen())
+                .filter(ticketOpenDate ->
+                        ticketOpenDate.getTicketOpenType().equals(TicketOpenType.GENERAL_OPEN))
                 .findFirst()
                 .orElse(null);
         LocalDateTime generalOpenDate = generalOpen != null ? generalOpen.getOpenDate() : null;

--- a/src/main/java/com/ticketmate/backend/service/concert/ConcertService.java
+++ b/src/main/java/com/ticketmate/backend/service/concert/ConcertService.java
@@ -167,16 +167,26 @@ public class ConcertService {
             log.error("선예매/일반예매 오픈일 데이터를 찾을 수 없습니다.");
             throw new CustomException(ErrorCode.TICKET_OPEN_DATE_NOT_FOUND);
         }
-        TicketOpenDate preOpen = preOpenDateList.get(0);
-        LocalDateTime preOpenDate = preOpen != null ? preOpen.getOpenDate() : null;
-        Integer preOpenRequestMaxCount = preOpen != null ? preOpen.getRequestMaxCount() : null;
-        Boolean preOpenIsBankTransfer = preOpen != null ? preOpen.getIsBankTransfer() : null;
 
-        TicketOpenDate generalOpen = generalOpenDateList.get(0);
-        LocalDateTime generalOpenDate = generalOpen != null ? generalOpen.getOpenDate() : null;
-        Integer generalOpenRequestMaxCount = generalOpen != null ? generalOpen.getRequestMaxCount() : null;
-        Boolean generalOpenIsBankTransfer = generalOpen != null ? generalOpen.getIsBankTransfer() : null;
+        LocalDateTime preOpenDate = null;
+        Integer preOpenRequestMaxCount = null;
+        Boolean preOpenIsBankTransfer = null;
+        if (!preOpenDateList.isEmpty()){
+            TicketOpenDate preOpen = preOpenDateList.get(0);
+            preOpenDate = preOpen != null ? preOpen.getOpenDate() : null;
+            preOpenRequestMaxCount = preOpen != null ? preOpen.getRequestMaxCount() : null;
+            preOpenIsBankTransfer = preOpen != null ? preOpen.getIsBankTransfer() : null;
+        }
 
+        LocalDateTime generalOpenDate = null;
+        Integer generalOpenRequestMaxCount = null;
+        Boolean generalOpenIsBankTransfer = null;
+        if (!generalOpenDateList.isEmpty()) {
+            TicketOpenDate generalOpen = generalOpenDateList.get(0);
+            generalOpenDate = generalOpen != null ? generalOpen.getOpenDate() : null;
+            generalOpenRequestMaxCount = generalOpen != null ? generalOpen.getRequestMaxCount() : null;
+            generalOpenIsBankTransfer = generalOpen != null ? generalOpen.getIsBankTransfer() : null;
+        }
 
         // 4. 반환값
         return ConcertInfoResponse.builder()

--- a/src/main/java/com/ticketmate/backend/service/test/TestService.java
+++ b/src/main/java/com/ticketmate/backend/service/test/TestService.java
@@ -525,12 +525,12 @@ public class TestService {
      */
     private List<ApplicationFormDetail> createApplicationFormDetailList(Concert concert, TicketOpenType ticketOpenType) {
         List<ConcertDate> concertDateList = concertDateRepository.findAllByConcertConcertId(concert.getConcertId());
-        int size = koFaker.random().nextInt(1, concertDateList.size() + 1);
-        List<ApplicationFormDetail> applicationFormDetailList = new ArrayList<>();
         if (CommonUtil.nullOrEmpty(concertDateList)) {
             log.error("신청서 세부사항 Mock 데이터 생성 중 공연: {}에 해당하는 공연 날짜가 존재하지 않습니다.", concert.getConcertName());
             throw new CustomException(ErrorCode.CONCERT_DATE_NOT_FOUND);
         }
+        int size = koFaker.random().nextInt(1, concertDateList.size() + 1);
+        List<ApplicationFormDetail> applicationFormDetailList = new ArrayList<>();
 
         // 선예매/일반예매 예매일 조회
         TicketOpenDate ticketOpenDate = ticketOpenDateRepository

--- a/src/main/java/com/ticketmate/backend/service/test/TestService.java
+++ b/src/main/java/com/ticketmate/backend/service/test/TestService.java
@@ -546,7 +546,7 @@ public class TestService {
 
         for (int i = 0; i < size; i++) {
             // 세부 요청별 요청 매수 (1 ~ Max장)
-            int requestCount = koFaker.random().nextInt(1, ticketOpenDate.getRequestMaxCount());
+            int requestCount = koFaker.random().nextInt(1, ticketOpenDate.getRequestMaxCount() + 1);
 
             // ApplicationFormDetail 생성
             ApplicationFormDetail applicationFormDetail = ApplicationFormDetail.builder()

--- a/src/main/java/com/ticketmate/backend/util/common/CommonUtil.java
+++ b/src/main/java/com/ticketmate/backend/util/common/CommonUtil.java
@@ -2,6 +2,8 @@ package com.ticketmate.backend.util.common;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
+
 /**
  * 공통 메서드
  */
@@ -39,6 +41,16 @@ public class CommonUtil {
             return 0;
         }
         return val;
+    }
+
+    /**
+     * 리스트가 null이거나 비어있는지 여부를 반환
+     *
+     * @param list 검증할 list
+     * @return 리스트가 null이거나 비어있으면 true, 그 외에는 false
+     */
+    public static boolean nullOrEmpty(List<?> list) {
+        return list == null || list.isEmpty();
     }
 
     /**

--- a/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
+++ b/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
@@ -7,12 +7,16 @@ import com.ticketmate.backend.object.dto.application.request.HopeAreaRequest;
 import com.ticketmate.backend.object.dto.application.response.ApplicationFormFilteredResponse;
 import com.ticketmate.backend.object.dto.application.response.ApplicationFormDetailResponse;
 import com.ticketmate.backend.object.dto.application.response.HopeAreaResponse;
+import com.ticketmate.backend.object.dto.concert.response.ConcertDateInfoResponse;
+import com.ticketmate.backend.object.dto.concert.response.TicketOpenDateInfoResponse;
 import com.ticketmate.backend.object.dto.concerthall.response.ConcertHallFilteredResponse;
 import com.ticketmate.backend.object.dto.concerthall.response.ConcertHallInfoResponse;
 import com.ticketmate.backend.object.dto.fcm.response.FcmTokenSaveResponse;
 import com.ticketmate.backend.object.postgres.application.ApplicationForm;
 import com.ticketmate.backend.object.postgres.application.ApplicationFormDetail;
 import com.ticketmate.backend.object.postgres.application.HopeArea;
+import com.ticketmate.backend.object.postgres.concert.ConcertDate;
+import com.ticketmate.backend.object.postgres.concert.TicketOpenDate;
 import com.ticketmate.backend.object.postgres.concerthall.ConcertHall;
 import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
 import com.ticketmate.backend.object.redis.FcmToken;
@@ -43,6 +47,11 @@ public interface EntityMapper {
 
     // Concert -> ConcertFilteredResponse (엔티티 -> DTO)
 
+    // List<ConcertDate> -> List<ConcertDateInfoResponse> (엔티티 리스트 -> DTO 리스트)
+    List<ConcertDateInfoResponse> toConcertDateInfoResponseList(List<ConcertDate> concertDateList);
+
+    // List<TicketOpenDate> -> List<TicketOpenDateInfoResponse> (엔티티 리스트 -> DTO 리스트)
+    List<TicketOpenDateInfoResponse> toTicketOpenDateInfoResponseList(List<TicketOpenDate> ticketOpenDateList);
 
 
     /*

--- a/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
+++ b/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
@@ -5,11 +5,12 @@ import com.ticketmate.backend.object.dto.admin.response.PortfolioForAdminRespons
 import com.ticketmate.backend.object.dto.admin.response.PortfolioListForAdminResponse;
 import com.ticketmate.backend.object.dto.application.request.HopeAreaRequest;
 import com.ticketmate.backend.object.dto.application.response.ApplicationFormFilteredResponse;
-import com.ticketmate.backend.object.dto.application.response.HopeAreaResponse;
+import com.ticketmate.backend.object.dto.application.response.ApplicationFormDetailResponse;
 import com.ticketmate.backend.object.dto.concerthall.response.ConcertHallFilteredResponse;
 import com.ticketmate.backend.object.dto.concerthall.response.ConcertHallInfoResponse;
 import com.ticketmate.backend.object.dto.fcm.response.FcmTokenSaveResponse;
 import com.ticketmate.backend.object.postgres.application.ApplicationForm;
+import com.ticketmate.backend.object.postgres.application.ApplicationFormDetail;
 import com.ticketmate.backend.object.postgres.application.HopeArea;
 import com.ticketmate.backend.object.postgres.concerthall.ConcertHall;
 import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
@@ -69,19 +70,27 @@ public interface EntityMapper {
     List<HopeArea> toHopeAreaList(List<HopeAreaRequest> hopeAreaRequestList);
 
     // HopeArea -> HopeAreaResponse (엔티티 -> DTO)
-    HopeAreaResponse toHopeAreaResponse(HopeArea hopeArea);
+    ApplicationFormDetailResponse toHopeAreaResponse(HopeArea hopeArea);
 
     // List<HopeArea> -> List<HopeAreaResponse> (엔티티 리스트 -> DTO 리스트)
-    List<HopeAreaResponse> toHopeAreaResponseList(List<HopeArea> hopeAreaList);
+    List<ApplicationFormDetailResponse> toHopeAreaResponseList(List<HopeArea> hopeAreaList);
+
+    // ApplicationFormDetail -> ApplicationFormDetailResponse (엔티티 -> DTO)
+    @Mapping(source = "concertDate.performanceDate", target = "performanceDate")
+    @Mapping(source = "concertDate.session", target = "session")
+    @Mapping(source = "hopeAreaList", target = "hopeAreaResponseList")
+    ApplicationFormDetailResponse toApplicationFormDetailResponse(ApplicationFormDetail applicationFormDetail);
+
+    // List<ApplicationFormDetail> -> List<ApplicationFormDetailResponse> (엔티티 리스트 -> DTO 리스트)
+    List<ApplicationFormDetailResponse> toApplicationFormDetailResponseList(List<ApplicationFormDetail> applicationFormDetailList);
 
     // ApplicationForm -> ApplicationFormFilteredResponse (엔티티 -> DTO)
     @Mapping(source = "client.memberId", target = "clientId")
     @Mapping(source = "agent.memberId", target = "agentId")
     @Mapping(source = "concert.concertId", target = "concertId")
-    @Mapping(source = "hopeAreaList", target = "hopeAreaResponseList")
-    @Mapping(source = "concertDate.performanceDate", target = "performanceDate")
     @Mapping(source = "ticketOpenDate.openDate", target = "openDate")
-    @Mapping(source = "ticketOpenDate.ticketOpenType", target = "ticketOpenType")
+    @Mapping(source = "applicationFormDetailList", target = "applicationFormDetailResponseList")
+    @Mapping(source = "totalRequestCount", target = "totalRequestCount")
     ApplicationFormFilteredResponse toApplicationFormFilteredResponse(ApplicationForm applicationForm);
   
   

--- a/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
+++ b/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
@@ -6,6 +6,7 @@ import com.ticketmate.backend.object.dto.admin.response.PortfolioListForAdminRes
 import com.ticketmate.backend.object.dto.application.request.HopeAreaRequest;
 import com.ticketmate.backend.object.dto.application.response.ApplicationFormFilteredResponse;
 import com.ticketmate.backend.object.dto.application.response.ApplicationFormDetailResponse;
+import com.ticketmate.backend.object.dto.application.response.HopeAreaResponse;
 import com.ticketmate.backend.object.dto.concerthall.response.ConcertHallFilteredResponse;
 import com.ticketmate.backend.object.dto.concerthall.response.ConcertHallInfoResponse;
 import com.ticketmate.backend.object.dto.fcm.response.FcmTokenSaveResponse;
@@ -70,10 +71,10 @@ public interface EntityMapper {
     List<HopeArea> toHopeAreaList(List<HopeAreaRequest> hopeAreaRequestList);
 
     // HopeArea -> HopeAreaResponse (엔티티 -> DTO)
-    ApplicationFormDetailResponse toHopeAreaResponse(HopeArea hopeArea);
+    HopeAreaResponse toHopeAreaResponse(HopeArea hopeArea);
 
     // List<HopeArea> -> List<HopeAreaResponse> (엔티티 리스트 -> DTO 리스트)
-    List<ApplicationFormDetailResponse> toHopeAreaResponseList(List<HopeArea> hopeAreaList);
+    List<HopeAreaResponse> toHopeAreaResponseList(List<HopeArea> hopeAreaList);
 
     // ApplicationFormDetail -> ApplicationFormDetailResponse (엔티티 -> DTO)
     @Mapping(source = "concertDate.performanceDate", target = "performanceDate")

--- a/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
+++ b/src/main/java/com/ticketmate/backend/util/common/EntityMapper.java
@@ -81,7 +81,7 @@ public interface EntityMapper {
     @Mapping(source = "hopeAreaList", target = "hopeAreaResponseList")
     @Mapping(source = "concertDate.performanceDate", target = "performanceDate")
     @Mapping(source = "ticketOpenDate.openDate", target = "openDate")
-    @Mapping(source = "ticketOpenDate.isPreOpen", target = "isPreOpen")
+    @Mapping(source = "ticketOpenDate.ticketOpenType", target = "ticketOpenType")
     ApplicationFormFilteredResponse toApplicationFormFilteredResponse(ApplicationForm applicationForm);
   
   

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -70,7 +70,7 @@ public enum ErrorCode {
 
     TICKET_OPEN_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "티켓 오픈일을 찾을 수 없습니다."),
 
-    TICKET_OPEN_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "티켓 오픈 타입을 찾을 수 없습니다."),
+    TICKET_OPEN_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "티켓 오픈 타입을 찾을 수 없습니다."),
 
     TICKET_REQUEST_COUNT_EXCEED(HttpStatus.BAD_REQUEST, "티켓 예매 요청 매수가 잘못되었습니다."),
 

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -103,6 +103,7 @@ public enum ErrorCode {
     PORTFOLIO_IMG_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "포트폴리오 등록을 위한 이미지는 최대 20장입니다."),
 
     // REDIS_LOCK
+
     LOCK_ACQUISITION_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "락 획득에 실패했습니다."),
 
     LOCK_ACQUISITION_INTERRUPT(HttpStatus.INTERNAL_SERVER_ERROR, "락 획득 중 인터럽트가 발생했습니다."),
@@ -120,6 +121,8 @@ public enum ErrorCode {
     ALREADY_APPROVED_APPLICATION_FROM(HttpStatus.BAD_REQUEST, "이미 수락된 신청서입니다."),
 
     INVALID_APPLICATION_FORM_STATUS(HttpStatus.BAD_REQUEST, "해당 신청서의 상태가 잘못됐습니다."),
+
+    APPLICATION_FORM_DETAIL_REQUIRED(HttpStatus.BAD_REQUEST, "신청서에는 최소 1개 이상의 공연일자가 포함되어야합니다."),
 
     // NOTIFICATION
 

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -60,11 +60,17 @@ public enum ErrorCode {
 
     INVALID_RANGE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 범위가 입력되었습니다."),
 
-    GENERAL_TICKET_OPEN_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "티켓 일반 예매 오픈일은 필수로 포함되어야 합니다."),
+    TICKET_OPEN_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "티켓 선예매/일반예매 오픈일은 필수로 포함되어야 합니다."),
+
+    PRE_OPEN_COUNT_EXCEED(HttpStatus.BAD_REQUEST, "선예매 오픈일 데이터는 최대 한개까지만 등록 가능합니다."),
+
+    GENERAL_OPEN_COUNT_EXCEED(HttpStatus.BAD_REQUEST, "일반예매 오픈일 데이터는 최대 한개까지만 등록 가능합니다."),
 
     CONCERT_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "공연 날짜 정보를 찾을 수 없습니다."),
 
     TICKET_OPEN_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "티켓 오픈일을 찾을 수 없습니다."),
+
+    TICKET_OPEN_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "티켓 오픈 타입을 찾을 수 없습니다."),
 
     TICKET_REQUEST_COUNT_EXCEED(HttpStatus.BAD_REQUEST, "티켓 예매 요청 매수가 잘못되었습니다."),
 


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 신청서 중복 여부를 확인하는 새로운 API가 추가되었습니다.
  - 티켓 오픈 타입을 명확하게 구분하는 enum(TicketOpenType)이 도입되었습니다.
  - 공연별 다중 공연일자 신청서 상세 내역을 지원하는 기능이 추가되었습니다.

- **Bug Fixes**
  - 티켓 오픈 타입 관련 필드가 Boolean에서 Enum으로 변경되어, 선예매/일반예매 구분이 더욱 명확해졌습니다.
  - 티켓 오픈일 데이터의 유효성 검증이 강화되어, 각 타입별로 최대 한 개만 등록할 수 있도록 개선되었습니다.

- **Documentation**
  - API 문서가 티켓 오픈 타입(enum) 기준으로 수정되고, 파라미터 설명 및 사용 예시가 명확해졌습니다.

- **Refactor**
  - 전반적으로 isPreOpen(Boolean) 필드가 ticketOpenType(Enum)으로 일괄 변경되었습니다.
  - 관련 서비스, 엔티티, DTO, 리포지토리, 매핑 로직이 Enum 기반으로 리팩터링되었습니다.
  - 신청서 및 티켓 오픈일 관련 데이터 구조가 다중 공연일자 및 상세 정보 반영으로 재구성되었습니다.

- **Chores**
  - 에러 코드가 세분화되어, 예외 상황에 대한 안내가 더 구체적으로 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->