### PR TITLE
20250529 #275 기능개선 포트폴리오 포트폴리오 업로드 및 조회 리팩토링

### DIFF
--- a/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/admin/docs/AdminControllerDocs.java
@@ -346,7 +346,7 @@ public interface AdminControllerDocs {
                     이 API는 관리자 인증이 필요합니다
                     
                     ### 요청 파라미터
-                    - 포트폴리오의 고유한 id                  
+                    - 포트폴리오의 고유한 id
                     
                     ### 유의사항
                     - 포트폴리오의 id를 활용해 포트폴리오 상세조회시 관라지에게 필요한 데이터를 반환합니다.
@@ -373,14 +373,14 @@ public interface AdminControllerDocs {
                     
                     ### PortfolioType
                     
-                    REVIEW_COMPLETED ("승인된 포트폴리오")
+                    ACCEPTED ("승인된 포트폴리오")
                     
-                    COMPANION("반려된 포트폴리오")
+                    REJECTED ("반려된 포트폴리오")
                     
                     ### 유의사항
                     - 관리자가 승인 요청이된 포트폴리오를 승인 및 반려하는 작업입니다.
-                    - 승인(REVIEW_COMPLETED)시 해당 포트폴리오의 상태가 "REVIEW_COMPLETED("승인된 포트폴리오")" 로 변경됩니다.
-                    - 반려(COMPANION)시 해당 포트폴리오의 상태가 "COMPANION("반려된 포트폴리오")" 로 변경됩니다. 
+                    - 승인(ACCEPTED)시 해당 포트폴리오의 상태가 "ACCEPTED("승인된 포트폴리오")" 로 변경됩니다.
+                    - 반려(REJECTED)시 해당 포트폴리오의 상태가 "REJECTED("반려된 포트폴리오")" 로 변경됩니다.
                     
                     ### 알림전송 특이사항
                     - 관리자가 포트폴리오를 승인 혹은 반려 상태로 변경합니다.

--- a/src/main/java/com/ticketmate/backend/controller/test/TestController.java
+++ b/src/main/java/com/ticketmate/backend/controller/test/TestController.java
@@ -12,8 +12,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.concurrent.CompletableFuture;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/test")
@@ -36,9 +34,10 @@ public class TestController implements TestControllerDocs {
     @Override
     @PostMapping(value = "/member")
     @LogMonitoringInvocation
-    public ResponseEntity<CompletableFuture<Integer>> generateMockMembers(
+    public ResponseEntity<Void> generateMockMembers(
             @RequestParam @Schema(defaultValue = "30") int count) {
-        return ResponseEntity.ok(testService.generateMockMembersAsync(count));
+        testService.generateMockMembersAsync(count);
+        return ResponseEntity.ok().build();
     }
 
     @Override
@@ -76,5 +75,12 @@ public class TestController implements TestControllerDocs {
         return ResponseEntity.ok().build();
     }
 
-
+    @Override
+    @PostMapping("/portfolio")
+    @LogMonitoringInvocation
+    public ResponseEntity<Void> createPortfolioMockData(
+            @Schema(defaultValue = "30") Integer count) {
+        testService.generateMockPortfoliosAsync(count);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/ticketmate/backend/controller/test/docs/TestControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/controller/test/docs/TestControllerDocs.java
@@ -4,8 +4,6 @@ import com.ticketmate.backend.object.dto.test.request.LoginRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 
-import java.util.concurrent.CompletableFuture;
-
 public interface TestControllerDocs {
 
     @Operation(
@@ -38,13 +36,6 @@ public interface TestControllerDocs {
                     
                     ### 🔄 응답 데이터
                     - HTTP 200 OK
-                    - 반환값: 생성된 회원 수 (Integer)
-                    
-                    ```json
-                    {
-                      "result": 10
-                    }
-                    ```
                     
                     ### 🛠️ 사용 방법
                     - 테스트 환경에서 회원 데이터가 필요할 때 사용하는 API입니다.
@@ -61,7 +52,7 @@ public interface TestControllerDocs {
                     - `INVALID_MEMBER_ROLE_REQUEST (400)`: 테스트 전용 Role(ROLE_TEST, ROLE_TEST_ADMIN) 외의 값이 요청될 경우
                     """
     )
-    ResponseEntity<CompletableFuture<Integer>> generateMockMembers(int count);
+    ResponseEntity<Void> generateMockMembers(int count);
 
     @Operation(
             summary = "테스트 회원 삭제",
@@ -128,4 +119,26 @@ public interface TestControllerDocs {
                     """
     )
     ResponseEntity<Void> createApplicationFormMockData(Integer count);
+
+    @Operation(
+            summary = "포트폴리오 Mock 데이터 비동기 생성",
+            description = """
+                    ### 요청 파라미터
+                    - `count` (int): 생성할 포트폴리오 Mock 데이터의 개수. 예: 10
+                    
+                    ### 응답 데이터
+                    - 본 API는 반환값이 없으며, 정상적으로 요청이 처리된 경우 HTTP 200 OK 상태 코드가 반환됩니다.
+                    
+                    ### 사용 방법 & 유의 사항
+                    - 이 API는 테스트나 개발 목적으로 포트폴리오 데이터를 대량으로 생성할 때 사용됩니다.
+                    - 내부적으로 멀티스레딩을 사용하여 비동기 방식으로 데이터를 생성하며, 모든 작업이 완료된 후 일괄 저장됩니다.
+                    - Portfolio 객체는 무작위로 생성되며, 포트폴리오 설명, 클라이언트 회원 정보, 포트폴리오 유형, 이미지 리스트를 포함합니다.
+                    - 생성된 포트폴리오는 실제 서비스와 무관한 테스트용 데이터입니다.
+                    - 동시에 다량의 데이터를 생성하므로 서버 부하에 유의해야 하며, 운영 환경에서는 사용하지 않는 것을 권장합니다.
+                    
+                    ### 예외 처리
+                    - `INTERNAL_SERVER_ERROR (500)`: 포트폴리오 데이터 생성 또는 저장 중 서버 내부 오류가 발생한 경우
+                    """
+    )
+    ResponseEntity<Void> createPortfolioMockData(Integer count);
 }

--- a/src/main/java/com/ticketmate/backend/object/constants/PortfolioType.java
+++ b/src/main/java/com/ticketmate/backend/object/constants/PortfolioType.java
@@ -6,9 +6,14 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum PortfolioType {
-    UNDER_REVIEW("포트폴리오 검토 대기중"),  // 관리자가 아직 보지않은 포트폴리오 (최초 업로드시 모두 해당상태로 저장됩니다.)
-    REVIEWING("포트폴리오 검토중"),  // 현재 관리자가 검토중인 포트폴리오
-    REVIEW_COMPLETED("승인된 포트폴리오"),  // 관리자가 승인해 의뢰인 -> 대리인으로 바뀐 포트폴리오
-    COMPANION("반려된 포트폴리오");  // 관리자에게 반려당한 포트폴리오
+
+    PENDING_REVIEW("검토 대기"),  // 관리자가 아직 보지않은 포트폴리오 (최초 업로드시 모두 해당상태로 저장됩니다.)
+
+    IN_REVIEW("검토 중"),  // 현재 관리자가 검토중인 포트폴리오
+
+    REVIEW_COMPLETED("승인"),  // 관리자가 승인해 의뢰인 -> 대리인으로 바뀐 포트폴리오
+
+    REVIEW_REJECTED("반려");  // 관리자에게 반려당한 포트폴리오
+
     private final String description;
 }

--- a/src/main/java/com/ticketmate/backend/object/constants/PortfolioType.java
+++ b/src/main/java/com/ticketmate/backend/object/constants/PortfolioType.java
@@ -11,9 +11,9 @@ public enum PortfolioType {
 
     IN_REVIEW("검토 중"),  // 현재 관리자가 검토중인 포트폴리오
 
-    REVIEW_COMPLETED("승인"),  // 관리자가 승인해 의뢰인 -> 대리인으로 바뀐 포트폴리오
+    ACCEPTED("승인"),  // 관리자가 승인해 의뢰인 -> 대리인으로 바뀐 포트폴리오
 
-    REVIEW_REJECTED("반려");  // 관리자에게 반려당한 포트폴리오
+    REJECTED("반려");  // 관리자에게 반려당한 포트폴리오
 
     private final String description;
 }

--- a/src/main/java/com/ticketmate/backend/object/constants/notification/PortfolioNotificationType.java
+++ b/src/main/java/com/ticketmate/backend/object/constants/notification/PortfolioNotificationType.java
@@ -29,9 +29,9 @@ public enum PortfolioNotificationType implements DomainNotificationType{
     private static final Map<PortfolioType, PortfolioNotificationType> MAPPING = new HashMap<>();
 
     static {
-        MAPPING.put(PortfolioType.REVIEWING, REVIEWING);
+        MAPPING.put(PortfolioType.IN_REVIEW, REVIEWING);
         MAPPING.put(PortfolioType.REVIEW_COMPLETED, REVIEW_COMPLETED);
-        MAPPING.put(PortfolioType.COMPANION, COMPANION);
+        MAPPING.put(PortfolioType.REVIEW_REJECTED, COMPANION);
     }
 
     /**

--- a/src/main/java/com/ticketmate/backend/object/constants/notification/PortfolioNotificationType.java
+++ b/src/main/java/com/ticketmate/backend/object/constants/notification/PortfolioNotificationType.java
@@ -30,8 +30,8 @@ public enum PortfolioNotificationType implements DomainNotificationType{
 
     static {
         MAPPING.put(PortfolioType.IN_REVIEW, REVIEWING);
-        MAPPING.put(PortfolioType.REVIEW_COMPLETED, REVIEW_COMPLETED);
-        MAPPING.put(PortfolioType.REVIEW_REJECTED, COMPANION);
+        MAPPING.put(PortfolioType.ACCEPTED, REVIEW_COMPLETED);
+        MAPPING.put(PortfolioType.REJECTED, COMPANION);
     }
 
     /**

--- a/src/main/java/com/ticketmate/backend/object/dto/admin/request/PortfolioStatusUpdateRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/admin/request/PortfolioStatusUpdateRequest.java
@@ -2,6 +2,7 @@ package com.ticketmate.backend.object.dto.admin.request;
 
 import com.ticketmate.backend.object.constants.PortfolioType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,6 +13,7 @@ import lombok.ToString;
 @Builder
 @ToString
 public class PortfolioStatusUpdateRequest {
-    @Schema(defaultValue = "REVIEW_COMPLETED")
+    @Schema(defaultValue = "ACCEPTED")
+    @Pattern(regexp = "^(ACCEPTED|REJECTED)$")
     private PortfolioType portfolioType;
 }

--- a/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormDetailRequest.java
+++ b/src/main/java/com/ticketmate/backend/object/dto/application/request/ApplicationFormDetailRequest.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class ApplicationFormDetailRequest {
 
     @NotNull(message = "공열일자를 입력하세요")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     @Schema(defaultValue = "2025-02-11T20:00:00")
     private LocalDateTime performanceDate; // 공연일자
 

--- a/src/main/java/com/ticketmate/backend/object/postgres/concert/ConcertDate.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/concert/ConcertDate.java
@@ -28,8 +28,8 @@ public class ConcertDate extends BasePostgresEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Concert concert; // 공연
 
-    @Column(nullable = false)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Column(nullable = false, columnDefinition = "TIMESTAMP(0)")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime performanceDate; // 공연 일자
 
     @Column(nullable = false)

--- a/src/main/java/com/ticketmate/backend/object/postgres/concert/TicketOpenDate.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/concert/TicketOpenDate.java
@@ -1,5 +1,6 @@
 package com.ticketmate.backend.object.postgres.concert;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.ticketmate.backend.object.constants.TicketOpenType;
 import com.ticketmate.backend.object.postgres.global.BasePostgresEntity;
@@ -28,6 +29,8 @@ public class TicketOpenDate extends BasePostgresEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Concert concert;
 
+    @Column(columnDefinition = "TIMESTAMP(0)")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime openDate; // 티켓 오픈일
 
     private Integer requestMaxCount; // 최대 예매 매수

--- a/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
+++ b/src/main/java/com/ticketmate/backend/object/postgres/portfolio/Portfolio.java
@@ -26,6 +26,7 @@ public class Portfolio extends BasePostgresEntity {
     @Column(updatable = false, nullable = false)
     private UUID portfolioId;
 
+    @Column(columnDefinition = "TEXT")
     private String portfolioDescription;  // 자기소개
 
     @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -37,8 +38,12 @@ public class Portfolio extends BasePostgresEntity {
     @Enumerated(EnumType.STRING)
     private PortfolioType portfolioType;
 
+    private static final int MAX_IMG_COUNT = 20;
+
     public void addImg(PortfolioImg img) {
-        this.getImgList().add(img);
-        img.setPortfolio(this);
+        if (this.getImgList().size() < MAX_IMG_COUNT) {
+            this.getImgList().add(img);
+            img.setPortfolio(this);
+        }
     }
 }

--- a/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
+++ b/src/main/java/com/ticketmate/backend/service/admin/AdminService.java
@@ -488,19 +488,21 @@ public class AdminService {
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PORTFOLIO_NOT_FOUND));
 
-        // 포트폴리오 상태 검토중 (IN_REVIEW)으로 변경
-        portfolio.setPortfolioType(PortfolioType.IN_REVIEW);
-
         // 포트폴리오 제출 회원 PK
         UUID memberId = portfolio.getMember().getMemberId();
 
-        // 알림 payload 설정
-        NotificationPayloadRequest payload = notificationUtil
-                .portfolioNotification(PortfolioType.IN_REVIEW, portfolio);
+        // 포트폴리오가 "검토 대기" 상태인 경우
+        if (portfolio.getPortfolioType().equals(PortfolioType.PENDING_REVIEW)) {
+            // 포트폴리오 상태 "검토중" (IN_REVIEW)으로 변경
+            portfolio.setPortfolioType(PortfolioType.IN_REVIEW);
 
-        // 알림 발송
-        fcmService.sendNotification(memberId, payload);
+            // 알림 payload 설정
+            NotificationPayloadRequest payload = notificationUtil
+                    .portfolioNotification(PortfolioType.IN_REVIEW, portfolio);
 
+            // 알림 발송
+            fcmService.sendNotification(memberId, payload);
+        }
         PortfolioForAdminResponse portfolioForAdminResponse = entityMapper.toPortfolioForAdminResponse(portfolio);
 
         List<PortfolioImg> imgList = portfolio.getImgList();

--- a/src/main/java/com/ticketmate/backend/service/application/ApplicationFormService.java
+++ b/src/main/java/com/ticketmate/backend/service/application/ApplicationFormService.java
@@ -39,10 +39,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static com.ticketmate.backend.object.constants.MemberType.AGENT;
 import static com.ticketmate.backend.object.constants.MemberType.CLIENT;
@@ -151,6 +148,7 @@ public class ApplicationFormService {
                 .agent(agent)
                 .concert(concert)
                 .ticketOpenDate(ticketOpenDate)
+                .applicationFormDetailList(new ArrayList<>())
                 .applicationFormStatus(ApplicationFormStatus.PENDING) // 신청서는 기본 '대기'상태
                 .ticketOpenType(request.getTicketOpenType())
                 .build();
@@ -177,6 +175,7 @@ public class ApplicationFormService {
                     .concertDate(concertDate)
                     .requestCount(detailRequest.getRequestCount())
                     .requirement(detailRequest.getRequestDetails())
+                    .hopeAreaList(new ArrayList<>())
                     .build();
 
             // 신청서 세부사항 희망구역 설정

--- a/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
+++ b/src/main/java/com/ticketmate/backend/service/portfolio/PortfolioService.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 public class PortfolioService {
     private final PortfolioRepository portfolioRepository;
     private final S3Service s3Service;
-    private static final Integer MAX_IMG_COUNT = 20;
+    private static final int MAX_IMG_COUNT = 20;
 
     /**
      * 포트폴리오 업로드
@@ -42,7 +42,7 @@ public class PortfolioService {
         Portfolio portfolio = Portfolio.builder()
                 .member(member)
                 .portfolioDescription(request.getPortfolioDescription())
-                .portfolioType(PortfolioType.UNDER_REVIEW)
+                .portfolioType(PortfolioType.PENDING_REVIEW)
                 .build();
 
         portfolioRepository.save(portfolio);

--- a/src/main/java/com/ticketmate/backend/service/test/MockMemberFactory.java
+++ b/src/main/java/com/ticketmate/backend/service/test/MockMemberFactory.java
@@ -40,7 +40,9 @@ public class MockMemberFactory {
     /**
      * 개발자용 회원 Mock 데이터 생성
      *
-     * @param request socialPlatform 네이버/카카오 소셜 로그인 플랫폼
+     * @param request username 이메일 (선택)
+     *                role 권한
+     *                socialPlatform 네이버/카카오 소셜 로그인 플랫폼
      *                memberType 의로인/대리인
      *                accountStatus 활성화/삭제
      *                isFirstLogin 첫 로그인 여부

--- a/src/main/java/com/ticketmate/backend/service/test/MockPortfolioFactory.java
+++ b/src/main/java/com/ticketmate/backend/service/test/MockPortfolioFactory.java
@@ -1,0 +1,70 @@
+package com.ticketmate.backend.service.test;
+
+import com.ticketmate.backend.object.constants.MemberType;
+import com.ticketmate.backend.object.constants.PortfolioType;
+import com.ticketmate.backend.object.constants.Role;
+import com.ticketmate.backend.object.dto.test.request.LoginRequest;
+import com.ticketmate.backend.object.postgres.Member.Member;
+import com.ticketmate.backend.object.postgres.portfolio.Portfolio;
+import com.ticketmate.backend.object.postgres.portfolio.PortfolioImg;
+import com.ticketmate.backend.repository.postgres.member.MemberRepository;
+import com.ticketmate.backend.util.common.CommonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.datafaker.Faker;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class MockPortfolioFactory {
+
+    private final Faker koFaker;
+    private final MockMemberFactory mockMemberFactory;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 포트폴리오 Mock 데이터 생성 (저장 X)
+     */
+    public Portfolio generate() {
+        String portfolioDescription = koFaker.lorem().sentence(5, 10);
+        Member client = mockMemberFactory.generate(LoginRequest.builder()
+                .role(Role.ROLE_TEST)
+                .memberType(MemberType.CLIENT)
+                .build());
+        memberRepository.save(client);
+
+        Portfolio portfolio = Portfolio.builder()
+                .portfolioDescription(portfolioDescription)
+                .member(client)
+                .portfolioType(koFaker.options().option(PortfolioType.class))
+                .build();
+
+        // 포트폴리오 이미지 추가 (양방향 관계 설정)
+        List<PortfolioImg> portfolioImgList = generatePortfolioImgList(portfolio);
+        if (!CommonUtil.nullOrEmpty(portfolioImgList)) {
+            portfolioImgList.forEach(portfolio::addImg);
+        }
+        return portfolio;
+    }
+
+    /**
+     * 포트폴리오 이미지 List Mock 데이터 생성 (0 ~ 20개 랜덤)
+     */
+    private List<PortfolioImg> generatePortfolioImgList(Portfolio portfolio) {
+        int count = koFaker.random().nextInt(21);
+        List<PortfolioImg> portfolioImgList = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            PortfolioImg portfolioImg = PortfolioImg.builder()
+                    .imgName(koFaker.internet().image())
+                    .build();
+            portfolioImgList.add(portfolioImg);
+        }
+
+        return portfolioImgList;
+    }
+}

--- a/src/main/java/com/ticketmate/backend/service/test/MockPortfolioFactory.java
+++ b/src/main/java/com/ticketmate/backend/service/test/MockPortfolioFactory.java
@@ -31,11 +31,7 @@ public class MockPortfolioFactory {
      */
     public Portfolio generate() {
         String portfolioDescription = koFaker.lorem().sentence(5, 10);
-        Member client = mockMemberFactory.generate(LoginRequest.builder()
-                .role(Role.ROLE_TEST)
-                .memberType(MemberType.CLIENT)
-                .build());
-        memberRepository.save(client);
+        Member client = createClientMember();
 
         Portfolio portfolio = Portfolio.builder()
                 .portfolioDescription(portfolioDescription)
@@ -66,5 +62,14 @@ public class MockPortfolioFactory {
         }
 
         return portfolioImgList;
+    }
+
+    // Mock 의뢰인 생성 및 저장
+    private Member createClientMember() {
+        Member member = mockMemberFactory.generate(LoginRequest.builder()
+                .role(Role.ROLE_TEST)
+                .memberType(MemberType.CLIENT)
+                .build());
+        return memberRepository.save(member);
     }
 }

--- a/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
+++ b/src/main/java/com/ticketmate/backend/util/exception/ErrorCode.java
@@ -110,6 +110,8 @@ public enum ErrorCode {
 
     PORTFOLIO_IMG_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "포트폴리오 등록을 위한 이미지는 최대 20장입니다."),
 
+    INVALID_PORTFOLIO_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 포트폴리오 타입 입니다."),
+
     // REDIS_LOCK
 
     LOCK_ACQUISITION_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "락 획득에 실패했습니다."),


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---
- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 포트폴리오 목업 데이터를 비동기로 생성하는 새로운 엔드포인트가 추가되었습니다. 기본 30개 생성이며, 개수 지정이 가능합니다.
    - 목업 포트폴리오 생성 기능이 추가되어 테스트용 데이터를 쉽게 만들 수 있습니다.
- **버그 수정**
    - 포트폴리오 상태 및 알림 타입 명칭이 더 명확하고 일관성 있게 변경되었습니다.
- **개선 사항**
    - 포트폴리오에 첨부할 수 있는 이미지 개수가 최대 20개로 제한됩니다.
    - 목업 멤버 및 포트폴리오 데이터 생성이 멀티스레드 방식으로 개선되어 성능이 향상되었습니다.
    - 포트폴리오 상태 변경 시 유효성 검증이 강화되고, 알림 전송 로직이 개선되었습니다.
- **문서화**
    - API 문서에 포트폴리오 목업 생성 엔드포인트가 추가되고, 멤버 목업 생성 설명이 갱신되었습니다.
    - 포트폴리오 상태 관련 API 문서 내 enum 명칭과 설명이 최신화되었습니다.
    - 목업 멤버 생성 관련 Javadoc이 상세하게 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->