### PR TITLE
[기능개선][채팅방] #338 채팅방 리스트업 필터링api 요청 파라미터 및 로직 리팩토링 (#341)

### DIFF
--- a/src/main/java/com/ticketmate/backend/domain/chat/controller/ChatRoomControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/domain/chat/controller/ChatRoomControllerDocs.java
@@ -15,6 +15,14 @@ import java.util.List;
 
 public interface ChatRoomControllerDocs {
 
+  @ApiChangeLogs({
+          @ApiChangeLog(
+                  date = "2025-06-24",
+                  author = "mr6208",
+                  description = "채팅방 리스트업 API 리팩토링",
+                  issueUrl = "https://github.com/Team-TicketMate/ticketmate-server/issues/338"
+          )
+  })
   @Operation(
       summary = "채팅방 리스트업",
       description = """
@@ -22,7 +30,7 @@ public interface ChatRoomControllerDocs {
           이 API는 인증이 필요합니다.
           
           ### 요청 파라미터
-          - **isPreOpen (PreOpenFilter)** : 선예매/일반예매 검색 카테고리 여부 [필수]
+          - **ticketOpenType (TicketOpenType)** : 선예매/일반예매 검색 카테고리 여부 [필수X]
           - **pageNumber (INTEGER)** : 요청 페이지 번호 [필수X]
           - **searchKeyword (STRING)** : 검색키워드 [필수X]
           
@@ -37,15 +45,14 @@ public interface ChatRoomControllerDocs {
           - **unRead** : 읽지 않은 메시지 카운트
           
           ### 사용 방법
-          `PreOpenFilter`
-          
-          ALL("선예매/일반예매 전체조회")
+          `TicketOpenType`
           
           PRE_OPEN("선예매")
           
-          NORMAL("일반예매")
+          GENERAL_OPEN("일반예매")
           
           ### 유의사항
+          - TicketOpenType파라미터를 공백 혹은 NULL로 요청 시 채팅방을 전체조회합니다.
           - 기본 페이징 처리는 페이지당 10개 데이터로 처리했습니다.
           - pageNumber는 기본 1페이지로 설정됩니다. (첫페이지)
           - 검색키워드가 없을 시 공백으로 설정합니다. (전체조회입니다.)

--- a/src/main/java/com/ticketmate/backend/domain/chat/domain/dto/request/ChatRoomFilteredRequest.java
+++ b/src/main/java/com/ticketmate/backend/domain/chat/domain/dto/request/ChatRoomFilteredRequest.java
@@ -1,6 +1,6 @@
 package com.ticketmate.backend.domain.chat.domain.dto.request;
 
-import com.ticketmate.backend.global.util.common.PageableUtil;
+import com.ticketmate.backend.domain.concert.domain.constant.TicketOpenType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
@@ -16,17 +16,12 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ChatRoomFilteredRequest {
-
-  @Schema(defaultValue = "ALL")
-  private PreOpenFilter isPreOpen;  // 선예매 일반예매 (Enum 사용으로 null 방지)
+  @Schema(defaultValue = "PRE_OPEN")
+  private TicketOpenType ticketOpenType;  // 선예매 일반예매
   @Min(value = 1, message = "페이지 번호는 최소 1부터 입니다.")
   @Schema(defaultValue = "1")
   private Integer pageNumber;  // 페이지 번호 (1부터 시작)
   @Schema(defaultValue = "")
   @Size(max = 30, message = "검색어는 최대 30자 입니다.")
   private String searchKeyword;  // 검색 키워드
-
-  public enum PreOpenFilter {
-    ALL, PRE_OPEN, NORMAL
-  }
 }

--- a/src/main/java/com/ticketmate/backend/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ticketmate/backend/domain/chat/service/ChatRoomService.java
@@ -10,7 +10,6 @@ import com.ticketmate.backend.domain.chat.domain.entity.ChatMessage;
 import com.ticketmate.backend.domain.chat.domain.entity.ChatRoom;
 import com.ticketmate.backend.domain.chat.repository.ChatMessageRepository;
 import com.ticketmate.backend.domain.chat.repository.ChatRoomRepository;
-import com.ticketmate.backend.domain.concert.domain.constant.TicketOpenType;
 import com.ticketmate.backend.domain.member.domain.entity.Member;
 import com.ticketmate.backend.domain.member.repository.MemberRepository;
 import com.ticketmate.backend.global.exception.CustomException;
@@ -53,24 +52,14 @@ public class ChatRoomService {
    */
   @Transactional(readOnly = true)
   public Page<ChatRoomListResponse> getChatRoomList(Member member, ChatRoomFilteredRequest request) {
-    // 필터링 관련 필드값 세팅
-    TicketOpenType preOpen = null;
-
+    // 검색 키워드 관련 필드값 세팅
     String keyword = nvl(request.getSearchKeyword(), "");
 
     // PageableUtil을 사용하여 1부터 시작하는 페이지 번호를 인덱스로 변환
     int pageIndex = PageableUtil.convertToPageIndex(request.getPageNumber());
 
-    if (request.getIsPreOpen().equals(ChatRoomFilteredRequest.PreOpenFilter.PRE_OPEN)) {
-      // 선예매만 필터링
-      preOpen = TicketOpenType.PRE_OPEN;
-    } else if (request.getIsPreOpen().equals(ChatRoomFilteredRequest.PreOpenFilter.NORMAL)) {
-      // 일반예매만 필터링
-      preOpen = TicketOpenType.GENERAL_OPEN;
-    }
-
     // 채팅방 리스트 불러오기 (10개씩)
-    Page<ChatRoom> chatRoomList = chatRoomRepository.search(preOpen, keyword, member, pageIndex);
+    Page<ChatRoom> chatRoomList = chatRoomRepository.search(request.getTicketOpenType(), keyword, member, pageIndex);
 
     // 채팅방마다 존재하는 신청폼 Id 리스트에 저장
     List<UUID> applicationFormIdList = chatRoomList.stream()

--- a/src/main/resources/static/chat-jwt.html
+++ b/src/main/resources/static/chat-jwt.html
@@ -1,15 +1,16 @@
 <!-- ************************************************************
-   TicketMate – 1 : 1 Chat 테스트 클라이언트 (Refactored v3.3, 2025‑06‑23)
+   TicketMate – 1 : 1 Chat 테스트 클라이언트 (Refactored v3.4, 2025‑06‑24)
    --------------------------------------------------------------
    * 신청서 패널 한국어 라벨 & 토글 버튼 한국어화 완료
    * renderApplicationForm() 한국어 필드 라벨 적용
    * 코드 전체 들여쓰기 정리
+   * 채팅방 리스트에 선예매/일반예매 표시 추가 (ticketOpenType 기반)
 ************************************************************* -->
 <!DOCTYPE html>
 <html lang="ko">
 <head>
   <meta charset="UTF-8" />
-  <title>TicketMate – 채팅방 1‑1 (v3.3)</title>
+  <title>TicketMate – 채팅방 1‑1 (v3.4)</title>
 
   <!-- 라이브러리 -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.6.1/sockjs.min.js"></script>
@@ -68,6 +69,28 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+
+    /* 📌 예매 타입 표시 */
+    .ticket-type {
+      font-size: 0.7rem;
+      padding: 0.2rem 0.5rem;
+      border-radius: 8px;
+      font-weight: bold;
+      margin-left: 0.5rem;
+    }
+    .ticket-type.pre-open {
+      background: #4CAF50;
+      color: white;
+    }
+    .ticket-type.general-open {
+      background: #2196F3;
+      color: white;
+    }
+    .room-info {
+      display: flex;
+      align-items: center;
+      margin-top: 0.15rem;
     }
 
     /* ====== 채팅 + 신청서 ====== */
@@ -195,11 +218,11 @@
 
 <script>
   /* CONFIG */
-  const API = "http://localhost:8080";
+  const API = "https://api.ticketmate.site";
   const BEARER = true;
   const TOKENS = {
-    client: "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJleGFtcGxlQG5hdmVyLmNvbSIsImNhdGVnb3J5IjoiYWNjZXNzIiwidXNlcm5hbWUiOiJleGFtcGxlQG5hdmVyLmNvbSIsIm1lbWJlcklkIjoiNmUzYTQxMWUtMmNjNS00NmVmLTliY2QtY2U0MDFkYmVkMzY1Iiwicm9sZSI6IlJPTEVfVEVTVCIsImlzcyI6IlRJQ0tFVF9NQVRFIiwiaWF0IjoxNzQ5NDY0MzgyLCJleHAiOjIxMDk0NjQzODJ9.gpUzai0TlvPDkpXS_JKYElOIfOrzeVBT8gC5LGFYLO7X0WzG3H6S1HYJazonv9vxt7EgEiZe1MdK_Oo3HmRr4A",
-    agent: "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJleGExMjNtcGxlQG5hdmVyLmNvbSIsImNhdGVnb3J5IjoiYWNjZXNzIiwidXNlcm5hbWUiOiJleGExMjNtcGxlQG5hdmVyLmNvbSIsIm1lbWJlcklkIjoiMTc1MzBlMmMtMzI4MC00MmQ4LWI0MTgtOGM2ZTI3ZTdlNzZiIiwicm9sZSI6IlJPTEVfVEVTVCIsImlzcyI6IlRJQ0tFVF9NQVRFIiwiaWF0IjoxNzQ5NDY0NDA3LCJleHAiOjIxMDk0NjQ0MDd9.GTLFf7MVIgQ1M6d2VHKRUw8W86lLERZy9MBdEA4L8SrHTCClEuzHXgbBKjOJvtsaXRf2ZNT2QxzK_2S0ivUnRA",
+    client: "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiLtgbTrnbzsnbTslrjtirjsmrDtmIFAbmF2ZXIuY29tNDI5IiwiY2F0ZWdvcnkiOiJhY2Nlc3MiLCJ1c2VybmFtZSI6Iu2BtOudvOydtOyWuO2KuOyasO2YgUBuYXZlci5jb200MjkiLCJtZW1iZXJJZCI6ImEyNTI2ZWQzLTczNmEtNDIyOS04OGQ0LWY4MzY1MmUzYjY4YiIsInJvbGUiOiJST0xFX1RFU1QiLCJpc3MiOiJUSUNLRVRfTUFURSIsImlhdCI6MTc1MDc1NDE4MywiZXhwIjoxNzUwODQwNTgzfQ.h-HXHGCdLyvlO2_h-2IhVgmsSG-NPLA6Hlc0aNxtelJqpWa0k8MB5NUYvY-4qKud",
+    agent: "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiLsl5DsnbTsoITtirjsmrDtmIFAbmF2ZXIuY29tNTg0IiwiY2F0ZWdvcnkiOiJhY2Nlc3MiLCJ1c2VybmFtZSI6IuyXkOydtOyghO2KuOyasO2YgUBuYXZlci5jb201ODQiLCJtZW1iZXJJZCI6Ijk2YmU4ZDU4LTY1NjktNGFjMS04NWIzLWE3ZjY2ZGY3ZDdiNCIsInJvbGUiOiJST0xFX1RFU1QiLCJpc3MiOiJUSUNLRVRfTUFURSIsImlhdCI6MTc1MDc1NDE1NSwiZXhwIjoxNzUwODQwNTU1fQ.zsxcLZ8X_bHw1DmZJc3wv4qoTzaTlWQDeK1O2yp0cUHkcb_-NPqaclyPVrgVukxu",
   };
 
   /* 상태 */
@@ -243,11 +266,27 @@
   const mUnread = (o) => o.unread ?? o.unReadMessageCount;
   const mLastMsg = (o) => o.lastMessage ?? o.lastChatMessage;
   const mLastSendTime = (o) => o.sentAt ?? o.lastChatSendTime;
+  const mTicketOpenType = (o) => o.ticketOpenType;
+
+  /* 📌 예매 타입 한글 변환 및 CSS 클래스 반환 */
+  const getTicketTypeInfo = (ticketOpenType) => {
+    switch (ticketOpenType) {
+      case "PRE_OPEN":
+        return { text: "선예매", className: "pre-open" };
+      case "GENERAL_OPEN":
+        return { text: "일반예매", className: "general-open" };
+      default:
+        return { text: "미정", className: "unknown" };
+    }
+  };
 
   /* ---------- DOM 헬퍼 ---------- */
-  function ensureItem(id, name) {
+  function ensureItem(id, name, ticketOpenType) {
     let el = document.querySelector(`.room-item[data-room-id="${id}"]`);
     if (el) return el;
+
+    const ticketTypeInfo = getTicketTypeInfo(ticketOpenType);
+
     el = document.createElement("div");
     el.className = "room-item";
     el.dataset.roomId = id;
@@ -257,12 +296,16 @@
             <span class="time" data-room-id="${id}"></span>
             <span class="badge" data-room-id="${id}" style="visibility:hidden"></span>
           </div>
-          <div class="preview" data-room-id="${id}"></div>
+          <div class="room-info">
+            <div class="preview" data-room-id="${id}"></div>
+            <span class="ticket-type ${ticketTypeInfo.className}">${ticketTypeInfo.text}</span>
+          </div>
         `;
     el.onclick = () => enterRoom(id);
     document.getElementById("roomList").appendChild(el);
     return el;
   }
+
   const upBadge = (id, n) => {
     const b = document.querySelector(`.badge[data-room-id="${id}"]`);
     if (b) {
@@ -282,14 +325,15 @@
   /* ---------- 1) 방 목록 ---------- */
   async function loadRooms() {
     const res = await fetch(
-            `${API}/api/chat-room/list?isPreOpen=ALL&pageNum=0`,
+            `${API}/api/chat-room/list?&pageNum=0`,
             { headers: { Authorization: BEARER ? "Bearer " + Token.get() : Token.get() } }
     );
     const rooms = (await res.json()).content || [];
     document.getElementById("roomList").innerHTML = "";
     rooms.forEach((r) => {
       const id = mRoomId(r);
-      ensureItem(id, r.chatRoomName);
+      const ticketOpenType = mTicketOpenType(r);
+      ensureItem(id, r.chatRoomName, ticketOpenType);
       upBadge(id, mUnread(r));
       upPrev(id, mLastMsg(r));
       upTime(id, mLastSendTime(r));
@@ -375,7 +419,7 @@
   /* ---------- 5) 신청서 정보 ---------- */
   async function loadApplicationForm(roomId) {
     try {
-      const res = await fetch(`${API}/api/chat-room/${roomId}/applicationForm`, {
+      const res = await fetch(`${API}/api/chat-room/${roomId}/application-form`, {
         headers: { Authorization: BEARER ? "Bearer " + Token.get() : Token.get() },
       });
       if (!res.ok) throw new Error(res.status);


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 채팅방 목록에 예매 유형(선예매, 일반예매) 뱃지가 표시됩니다.

- **버그 수정**
  - 신청서 조회 경로가 `/applicationForm`에서 `/application-form`으로 수정되었습니다.

- **문서**
  - 채팅방 리스트 API의 파라미터 명칭 및 설명이 변경되고, 사용 방법 안내가 업데이트되었습니다.  
  - API 변경 내역이 문서에 추가되었습니다.

- **스타일**
  - 예매 유형 뱃지에 대한 색상 및 스타일이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->