### PR TITLE
20250715 #417 기능추가 테스트 대리인 Mock 데이터 생성 로직 확장

### DIFF
--- a/src/main/java/com/ticketmate/backend/test/controller/TestControllerDocs.java
+++ b/src/main/java/com/ticketmate/backend/test/controller/TestControllerDocs.java
@@ -38,6 +38,12 @@ public interface TestControllerDocs {
           author = "Chuseok22",
           description = "회원 Mock 데이터 예외처리 로직 추가",
           issueUrl = "https://github.com/Team-TicketMate/ticketmate-server/issues/315"
+      ),
+      @ApiChangeLog(
+          date = "2025-07-15",
+          author = "Yooonjeong",
+          description = "대리인 Mock 데이터 Summary 생성 및 랜덤 공연 수락 설정 추가",
+          issueUrl = "https://github.com/Team-TicketMate/ticketmate-server/issues/417"
       )
   })
   @Operation(
@@ -58,6 +64,8 @@ public interface TestControllerDocs {
           - `count`가 1 미만일 경우 기본값 1로 처리됩니다.
           - 생성된 회원 정보는 랜덤 데이터 기반이며 실제 유저 데이터가 아닙니다.
           - 해당 API는 운영 환경에서 사용하지 않도록 주의해야 합니다.
+          - **DB에 콘서트 데이터가 최소 1개 이상 존재해야 합니다.**
+          - 대리인 및 의뢰인 정보가 함께 생성되며, 대리인 생성 시 해당 대리인의 활동 정보가 랜덤값으로 추가되고 DB에 존재하는 랜덤 공연에 대해 수락 ON 설정됩니다.
           
           ### ❌ 예외 처리
           - `INTERNAL_SERVER_ERROR (500)`: 회원 Mock 데이터 저장 중 예기치 못한 오류가 발생한 경우

--- a/src/main/java/com/ticketmate/backend/test/service/MockMemberFactory.java
+++ b/src/main/java/com/ticketmate/backend/test/service/MockMemberFactory.java
@@ -2,10 +2,14 @@ package com.ticketmate.backend.test.service;
 
 import static com.ticketmate.backend.global.util.common.CommonUtil.nvl;
 
+import com.ticketmate.backend.domain.concert.domain.entity.Concert;
+import com.ticketmate.backend.domain.concert.domain.entity.ConcertAgentAvailability;
 import com.ticketmate.backend.domain.member.domain.constant.AccountStatus;
 import com.ticketmate.backend.domain.member.domain.constant.MemberType;
 import com.ticketmate.backend.domain.member.domain.constant.Role;
 import com.ticketmate.backend.domain.member.domain.constant.SocialPlatform;
+import com.ticketmate.backend.domain.member.domain.entity.AgentPerformanceSummary;
+import com.ticketmate.backend.domain.member.repository.AgentPerformanceSummaryRepository;
 import com.ticketmate.backend.test.dto.request.LoginRequest;
 import com.ticketmate.backend.domain.member.domain.entity.Member;
 import com.ticketmate.backend.global.exception.CustomException;
@@ -26,6 +30,7 @@ public class MockMemberFactory {
 
   private final Faker koFaker;
   private final Faker enFaker;
+
 
   /**
    * 개발자용 회원 Mock 데이터 생성
@@ -110,5 +115,33 @@ public class MockMemberFactory {
       log.error("Mock 회원은 TEST, TEST_ADMIN 권한만 부여할 수 있습니다. 요청된 ROLE: {}", role);
       throw new CustomException(ErrorCode.INVALID_MEMBER_ROLE_REQUEST);
     }
+  }
+
+  // AgentPerformanceSummary 객체 생성 및 랜덤 정수 부여
+  public AgentPerformanceSummary generatePerformanceSummary(Member agent){
+    int reviewCount = koFaker.number().numberBetween(0, 100);
+    int followerCount = koFaker.number().numberBetween(0, 300);
+    int recentSuccessCount = koFaker.number().numberBetween(0, 50);
+    double averageRating = koFaker.number().randomDouble(1, 0, 5);
+    long totalScore = koFaker.number().numberBetween(0, 100);
+
+    return AgentPerformanceSummary.builder()
+        .agent(agent)
+        .reviewCount(reviewCount)
+        .followerCount(followerCount)
+        .averageRating(averageRating)
+        .recentSuccessCount(recentSuccessCount)
+        .totalScore(totalScore)
+        .build();
+  }
+
+  // 공연에 대해 대리인의 수락 ON 설정하는 ConcertAgentAvailability 객체 생성
+  public ConcertAgentAvailability generateAvailability(Concert concert, Member agent) {
+    return ConcertAgentAvailability.builder()
+        .concert(concert)
+        .agent(agent)
+        .accepting(true)
+        .introduction("...")
+        .build();
   }
 }

--- a/src/main/java/com/ticketmate/backend/test/service/MockMemberFactory.java
+++ b/src/main/java/com/ticketmate/backend/test/service/MockMemberFactory.java
@@ -141,7 +141,7 @@ public class MockMemberFactory {
         .concert(concert)
         .agent(agent)
         .accepting(true)
-        .introduction("...")
+        .introduction(koFaker.lorem().sentence(5, 0))
         .build();
   }
 }


### PR DESCRIPTION
## ✨ 변경 사항
--- 


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 회원 Mock 데이터 생성 시, 대리인(AGENT) 회원에 대한 요약 정보 및 콘서트 수락 여부 Mock 데이터가 함께 생성됩니다.
  * 데이터베이스에 최소 1개 이상의 콘서트가 존재해야 Mock 데이터 생성을 진행할 수 있습니다.

* **Documentation**
  * API 문서에 대리인 요약 및 콘서트 수락 Mock 데이터 생성 관련 설명과 주의사항이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->