### PR TITLE
20250826 #434 기능개선 마이페이지 팔로워팔로잉 목록 조회 api 개발

### DIFF
--- a/ticketmate-api/src/main/java/com/ticketmate/backend/api/application/controller/member/MemberController.java
+++ b/ticketmate-api/src/main/java/com/ticketmate/backend/api/application/controller/member/MemberController.java
@@ -68,7 +68,7 @@ public class MemberController implements MemberControllerDocs {
   @LogMonitoringInvocation
   public ResponseEntity<Slice<MemberFollowResponse>> filteredMemberFollow(
       @PathVariable(name = "client-id") UUID clientId,
-      @ParameterObject MemberFollowFilteredRequest request) {
+      @Valid @ParameterObject MemberFollowFilteredRequest request) {
     return ResponseEntity.ok(memberFollowService.filteredMemberFollow(clientId, request));
   }
 }

--- a/ticketmate-api/src/main/java/com/ticketmate/backend/api/application/controller/member/MemberController.java
+++ b/ticketmate-api/src/main/java/com/ticketmate/backend/api/application/controller/member/MemberController.java
@@ -2,16 +2,22 @@ package com.ticketmate.backend.api.application.controller.member;
 
 import com.ticketmate.backend.auth.infrastructure.oauth2.CustomOAuth2User;
 import com.ticketmate.backend.common.application.annotation.LogMonitoringInvocation;
-import com.ticketmate.backend.member.application.dto.request.FollowRequest;
+import com.ticketmate.backend.member.application.dto.request.MemberFollowFilteredRequest;
+import com.ticketmate.backend.member.application.dto.request.MemberFollowRequest;
+import com.ticketmate.backend.member.application.dto.response.MemberFollowResponse;
 import com.ticketmate.backend.member.application.dto.response.MemberInfoResponse;
 import com.ticketmate.backend.member.application.service.MemberFollowService;
 import com.ticketmate.backend.member.application.service.MemberService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,7 +48,7 @@ public class MemberController implements MemberControllerDocs {
   @LogMonitoringInvocation
   public ResponseEntity<Void> follow(
       @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-      @Valid @RequestBody FollowRequest request) {
+      @Valid @RequestBody MemberFollowRequest request) {
     memberFollowService.follow(customOAuth2User.getMember(), request);
     return ResponseEntity.ok().build();
   }
@@ -52,8 +58,17 @@ public class MemberController implements MemberControllerDocs {
   @LogMonitoringInvocation
   public ResponseEntity<Void> unfollow(
       @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-      @Valid @RequestBody FollowRequest request) {
+      @Valid @RequestBody MemberFollowRequest request) {
     memberFollowService.unfollow(customOAuth2User.getMember(), request);
     return ResponseEntity.ok().build();
+  }
+
+  @Override
+  @GetMapping("/follow/{client-id}")
+  @LogMonitoringInvocation
+  public ResponseEntity<Slice<MemberFollowResponse>> filteredMemberFollow(
+      @PathVariable(name = "client-id") UUID clientId,
+      @ParameterObject MemberFollowFilteredRequest request) {
+    return ResponseEntity.ok(memberFollowService.filteredMemberFollow(clientId, request));
   }
 }

--- a/ticketmate-api/src/main/java/com/ticketmate/backend/api/application/controller/member/MemberControllerDocs.java
+++ b/ticketmate-api/src/main/java/com/ticketmate/backend/api/application/controller/member/MemberControllerDocs.java
@@ -3,9 +3,13 @@ package com.ticketmate.backend.api.application.controller.member;
 import com.chuseok22.apichangelog.annotation.ApiChangeLog;
 import com.chuseok22.apichangelog.annotation.ApiChangeLogs;
 import com.ticketmate.backend.auth.infrastructure.oauth2.CustomOAuth2User;
-import com.ticketmate.backend.member.application.dto.request.FollowRequest;
+import com.ticketmate.backend.member.application.dto.request.MemberFollowFilteredRequest;
+import com.ticketmate.backend.member.application.dto.request.MemberFollowRequest;
+import com.ticketmate.backend.member.application.dto.response.MemberFollowResponse;
 import com.ticketmate.backend.member.application.dto.response.MemberInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import java.util.UUID;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 
 public interface MemberControllerDocs {
@@ -69,7 +73,7 @@ public interface MemberControllerDocs {
           - 인증 정보가 없거나 잘못된 경우에는 컨트롤러에 진입하지 않고 보안 필터에서 차단됩니다.
           """
   )
-  public ResponseEntity<MemberInfoResponse> getMemberInfo(
+  ResponseEntity<MemberInfoResponse> getMemberInfo(
       CustomOAuth2User customOAuth2User);
 
   @ApiChangeLogs({
@@ -108,9 +112,9 @@ public interface MemberControllerDocs {
           - 이미 팔로우한 대상에 대해 중복 호출 시 에러가 발생합니다.
           """
   )
-  public ResponseEntity<Void> follow(
+  ResponseEntity<Void> follow(
       CustomOAuth2User customOAuth2User,
-      FollowRequest request);
+      MemberFollowRequest request);
 
   @ApiChangeLogs({
       @ApiChangeLog(
@@ -150,7 +154,54 @@ public interface MemberControllerDocs {
           - 팔로우하지 않은 대상에 대해 언팔로우 호출 시 에러가 발생합니다.
           """
   )
-  public ResponseEntity<Void> unfollow(
+  ResponseEntity<Void> unfollow(
       CustomOAuth2User customOAuth2User,
-      FollowRequest request);
+      MemberFollowRequest request);
+
+  @Operation(
+      summary = "팔로우 리스트 필터링 조회",
+      description = """
+        의뢰인(client-id)이 '팔로우하고 있는' 대리인 목록을 조회합니다.
+        
+        ### 엔드포인트
+        - `GET /api/member/follow/{client-id}`
+        - `client-id`는 **PathVariable(UUID)** 입니다.
+        
+        ### 요청 파라미터
+        - `pageNumber` (Integer, optional, default **1**)
+          - 유효성: 최소 1
+        - `pageSize` (Integer, optional, default **PageableConstants.DEFAULT_PAGE_SIZE**)
+          - 유효성: 최소 1, 최대 **PageableConstants.MAX_PAGE_SIZE**
+        - `sortField` (MemberFollowSortField, optional, default **CREATED_DATE**)
+          - 허용 값: `CREATED_DATE`, `FOLLOWER_COUNT`
+          - `CREATED_DATE`는 팔로우 관계의 생성 시점을 기준으로 정렬
+          - `FOLLOWER_COUNT`는 팔로우 대상 회원(=followee)의 총 팔로워 수를 기준으로 정렬
+        - `sortDirection` (Sort.Direction, optional, default **DESC**)
+          - 허용 값: `ASC`, `DESC`
+        
+        ### 응답 데이터
+        - 응답 형식: `Slice<MemberFollowResponse>`
+        - 콘텐츠 항목(`MemberFollowResponse`)은 아래 정보를 포함합니다.
+          - `nickname` : 팔로우 대상 회원의 닉네임
+          - `profileUrl` : 팔로우 대상 회원의 프로필 이미지 URL
+          - `followerCount` : 팔로우 대상 회원의 총 팔로워 수
+        - ※ `Slice<...>`는 페이지 끝 여부 등 슬라이싱 정보와 함께 `MemberFollowResponse` 항목들의 모음으로 반환됩니다. 실제 직렬화 구조는 서버의 공통 응답 설정을 따릅니다.
+        
+        ### 요청 예시
+        - 생성일 최신순(기본값) 1페이지 조회
+          - `GET /api/member/follow/{client-id}?pageNumber=1&pageSize=5&sortField=CREATED_DATE&sortDirection=DESC`
+        - 팔로워 수 내림차순 정렬
+          - `GET /api/member/follow/{client-id}?pageNumber=2&pageSize=5&sortField=FOLLOWER_COUNT&sortDirection=DESC`
+        
+        ### 유의 사항
+        - `pageNumber`는 **1부터 시작**합니다.
+        - `pageSize`는 서버 정책상 최대치(**PageableConstants.MAX_PAGE_SIZE**)를 초과할 수 없습니다.
+        - `sortField=FOLLOWER_COUNT`를 사용하면, 정렬 기준은 **팔로우 대상 회원(AGENT)의 `followerCount`**입니다.
+        - 본 API는 `client-id`에 해당하는 회원이 **팔로우하고 있는** 사용자들만을 반환합니다(팔로워 목록이 아님).
+        """
+  )
+  ResponseEntity<Slice<MemberFollowResponse>> filteredMemberFollow(
+      UUID clientId,
+      MemberFollowFilteredRequest request
+  );
 }

--- a/ticketmate-auth/src/main/java/com/ticketmate/backend/auth/infrastructure/oauth2/CustomOAuth2UserService.java
+++ b/ticketmate-auth/src/main/java/com/ticketmate/backend/auth/infrastructure/oauth2/CustomOAuth2UserService.java
@@ -62,13 +62,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
           .birthDay(oAuth2Response.getBirthDay())
           .birthYear(oAuth2Response.getBirthYear())
           .phone(oAuth2Response.getPhone())
-          .gender(oAuth2Response.getGender())
           .profileUrl(null)
+          .gender(oAuth2Response.getGender())
           .role(Role.ROLE_USER)
           .memberType(MemberType.CLIENT)
           .accountStatus(AccountStatus.ACTIVE_ACCOUNT)
           .isFirstLogin(true)
           .lastLoginTime(LocalDateTime.now(clock))
+          .followingCount(0L)
+          .followerCount(0L)
           .build();
     } else { // 첫 로그인이 아닌경우
       member = optionalMember.get();

--- a/ticketmate-member/src/main/java/com/ticketmate/backend/member/application/dto/request/MemberFollowFilteredRequest.java
+++ b/ticketmate-member/src/main/java/com/ticketmate/backend/member/application/dto/request/MemberFollowFilteredRequest.java
@@ -1,0 +1,47 @@
+package com.ticketmate.backend.member.application.dto.request;
+
+import com.ticketmate.backend.common.infrastructure.constant.PageableConstants;
+import com.ticketmate.backend.common.infrastructure.util.PageableUtil;
+import com.ticketmate.backend.member.core.constant.MemberFollowSortField;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+@Getter
+@AllArgsConstructor
+public class MemberFollowFilteredRequest {
+
+  @Min(value = 1, message = "페이지 번호는 1이상 값을 입력해야합니다.")
+  @Max(value = Integer.MAX_VALUE, message = "정수 최대 범위를 넘을 수 없습니다.")
+  private Integer pageNumber;
+
+  @Min(value = 1, message = "페이지 당 데이터 최솟값은 1개 입니다.")
+  @Max(value = PageableConstants.MAX_PAGE_SIZE, message = "페이지 당 데이터 최댓값은 " + PageableConstants.MAX_PAGE_SIZE + "개 입니다.")
+  private Integer pageSize;
+
+  private MemberFollowSortField sortField;
+
+  private Sort.Direction sortDirection;
+
+  // 기본값 할당 (1페이지 10개, 최신순)
+  public MemberFollowFilteredRequest() {
+    this.pageNumber = 1;
+    this.pageSize = PageableConstants.DEFAULT_PAGE_SIZE;
+    this.sortField = MemberFollowSortField.CREATED_DATE;
+    this.sortDirection = Direction.DESC;
+  }
+
+  public Pageable toPageable() {
+    return PageableUtil.createPageable(
+        pageNumber,
+        pageSize,
+        PageableConstants.DEFAULT_PAGE_SIZE,
+        sortField,
+        sortDirection
+    );
+  }
+}

--- a/ticketmate-member/src/main/java/com/ticketmate/backend/member/application/dto/request/MemberFollowRequest.java
+++ b/ticketmate-member/src/main/java/com/ticketmate/backend/member/application/dto/request/MemberFollowRequest.java
@@ -5,15 +5,17 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
 @ToString
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Setter
 @Builder
-public class FollowRequest {
+public class MemberFollowRequest {
 
   @NotNull(message = "팔로우/언팔로우 대상 회원 PK를 입력하세요")
   private UUID followeeId; // 팔로우/언팔로우 대상자 pk

--- a/ticketmate-member/src/main/java/com/ticketmate/backend/member/application/dto/response/MemberFollowResponse.java
+++ b/ticketmate-member/src/main/java/com/ticketmate/backend/member/application/dto/response/MemberFollowResponse.java
@@ -1,0 +1,9 @@
+package com.ticketmate.backend.member.application.dto.response;
+
+public record MemberFollowResponse(
+    String nickname,
+    String profileUrl,
+    long followerCount
+) {
+
+}

--- a/ticketmate-member/src/main/java/com/ticketmate/backend/member/application/service/MemberFollowService.java
+++ b/ticketmate-member/src/main/java/com/ticketmate/backend/member/application/service/MemberFollowService.java
@@ -1,15 +1,20 @@
 package com.ticketmate.backend.member.application.service;
 
-import com.ticketmate.backend.member.application.dto.request.FollowRequest;
+import com.ticketmate.backend.member.application.dto.request.MemberFollowFilteredRequest;
+import com.ticketmate.backend.member.application.dto.request.MemberFollowRequest;
+import com.ticketmate.backend.member.application.dto.response.MemberFollowResponse;
 import com.ticketmate.backend.member.application.validator.MemberFollowValidator;
 import com.ticketmate.backend.member.infrastructure.entity.Member;
 import com.ticketmate.backend.member.infrastructure.entity.MemberFollow;
 import com.ticketmate.backend.member.infrastructure.repository.MemberFollowRepository;
+import com.ticketmate.backend.member.infrastructure.repository.MemberFollowRepositoryCustom;
 import com.ticketmate.backend.notification.application.dto.request.NotificationPayload;
 import com.ticketmate.backend.notification.application.type.FollowingNotificationType;
 import com.ticketmate.backend.notification.core.service.NotificationService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberFollowService {
 
   private final MemberFollowRepository memberFollowRepository;
+  private final MemberFollowRepositoryCustom memberFollowRepositoryCustom;
   private final MemberService memberService;
   private final NotificationService notificationService;
 
@@ -28,7 +34,7 @@ public class MemberFollowService {
    * @param request followeeId 팔로우 대상 PK
    */
   @Transactional
-  public void follow(Member follower, FollowRequest request) {
+  public void follow(Member follower, MemberFollowRequest request) {
     Member followee = memberService.findMemberById(request.getFolloweeId());
 
     MemberFollowValidator.of(follower, followee)
@@ -49,7 +55,7 @@ public class MemberFollowService {
    * @param request followeeId 언팔로우 대상 PK
    */
   @Transactional
-  public void unfollow(Member follower, FollowRequest request) {
+  public void unfollow(Member follower, MemberFollowRequest request) {
     Member followee = memberService.findMemberById(request.getFolloweeId());
 
     MemberFollowValidator.of(follower, followee)
@@ -58,6 +64,14 @@ public class MemberFollowService {
         .validateUnfollowAble(memberFollowRepository);
 
     deleteMemberFollowEntity(follower, followee);
+  }
+
+  /**
+   * 팔로우 리스트 필터링 조회
+   */
+  @Transactional(readOnly = true)
+  public Slice<MemberFollowResponse> filteredMemberFollow(UUID clientId, MemberFollowFilteredRequest request) {
+    return memberFollowRepositoryCustom.filteredMemberFollow(clientId, request.toPageable());
   }
 
   /**

--- a/ticketmate-member/src/main/java/com/ticketmate/backend/member/core/constant/MemberFollowSortField.java
+++ b/ticketmate-member/src/main/java/com/ticketmate/backend/member/core/constant/MemberFollowSortField.java
@@ -1,0 +1,23 @@
+package com.ticketmate.backend.member.core.constant;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.ticketmate.backend.common.core.constant.SortField;
+import com.ticketmate.backend.common.core.util.CommonUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberFollowSortField implements SortField {
+
+  CREATED_DATE("createdDate"),
+
+  FOLLOWER_COUNT("followerCount");
+
+  private final String property;
+
+  @JsonCreator
+  public static MemberFollowSortField from(String value) {
+    return CommonUtil.stringToSortField(MemberFollowSortField.class, value);
+  }
+}

--- a/ticketmate-member/src/main/java/com/ticketmate/backend/member/infrastructure/repository/MemberFollowRepositoryCustom.java
+++ b/ticketmate-member/src/main/java/com/ticketmate/backend/member/infrastructure/repository/MemberFollowRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.ticketmate.backend.member.infrastructure.repository;
+
+import com.ticketmate.backend.member.application.dto.response.MemberFollowResponse;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface MemberFollowRepositoryCustom {
+
+  // 팔로우 필터링 조회
+  Slice<MemberFollowResponse> filteredMemberFollow(
+      UUID clientId,
+      Pageable pageable
+  );
+
+}

--- a/ticketmate-member/src/main/java/com/ticketmate/backend/member/infrastructure/repository/MemberFollowRepositoryImpl.java
+++ b/ticketmate-member/src/main/java/com/ticketmate/backend/member/infrastructure/repository/MemberFollowRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.ticketmate.backend.member.infrastructure.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ticketmate.backend.member.application.dto.response.MemberFollowResponse;
+import com.ticketmate.backend.member.core.constant.MemberFollowSortField;
+import com.ticketmate.backend.member.infrastructure.entity.MemberFollow;
+import com.ticketmate.backend.member.infrastructure.entity.QMember;
+import com.ticketmate.backend.member.infrastructure.entity.QMemberFollow;
+import com.ticketmate.backend.querydsl.infrastructure.util.QueryDslUtil;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberFollowRepositoryImpl implements MemberFollowRepositoryCustom {
+
+  private static final QMemberFollow MEMBER_FOLLOW = QMemberFollow.memberFollow;
+  private static final QMember CLIENT = new QMember("client");
+  private static final QMember AGENT = new QMember("agent");
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Slice<MemberFollowResponse> filteredMemberFollow(UUID clientId, Pageable pageable) {
+
+    // 동적 WHERE 절 조합
+    BooleanExpression whereClause = QueryDslUtil.allOf(
+        QueryDslUtil.eqIfNotNull(CLIENT.memberId, clientId)
+    );
+
+    // contentQuery 생성
+    JPAQuery<MemberFollowResponse> contentQuery = queryFactory
+        .select(Projections.constructor(
+            MemberFollowResponse.class,
+            AGENT.nickname,
+            AGENT.profileUrl,
+            AGENT.followerCount
+        ))
+        .from(MEMBER_FOLLOW)
+        .innerJoin(MEMBER_FOLLOW.follower, CLIENT)
+        .innerJoin(MEMBER_FOLLOW.followee, AGENT)
+        .where(whereClause);
+
+    ComparableExpression<Long> agentFollowerCountExpression = Expressions.comparableTemplate(
+        Long.class,
+        "{0}",
+        AGENT.followerCount
+    );
+
+    Map<String, ComparableExpression<?>> customSortMap = Collections.singletonMap(
+        MemberFollowSortField.FOLLOWER_COUNT.getProperty(),
+        agentFollowerCountExpression
+    );
+
+    // applySorting 동적 정렬 적용
+    QueryDslUtil.applySorting(
+        contentQuery,
+        pageable,
+        MemberFollow.class,
+        MEMBER_FOLLOW.getMetadata().getName(),
+        customSortMap
+    );
+
+    // Slice 페이징
+    return QueryDslUtil.fetchSlice(contentQuery, pageable);
+  }
+}


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - GET /api/member/follow/{client-id} 추가: 팔로우 목록을 페이지네이션·정렬로 조회. 응답에 닉네임, 프로필 URL, 팔로워 수 포함.
- Refactor
  - 팔로우/언팔로우 요청 본문 스키마가 변경되어 클라이언트 요청 형식 확인 필요.
  - 신규 정렬 필드 및 페이징 기본값 적용으로 정렬·페이지 동작 개선.
- Documentation
  - 신규 API 및 페이징/정렬 파라미터, 변경된 요청 스키마 문서화.
- Chores
  - 신규 회원 생성 시 팔로잉/팔로워 수 초기값 0 설정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->