### PR TITLE
20250912 #527 버그 db websiteurl 빈 문자열 저장으로 unique 위반 발생

### DIFF
--- a/ticketmate-common/src/main/java/com/ticketmate/backend/common/infrastructure/converter/NullIfBlankConverter.java
+++ b/ticketmate-common/src/main/java/com/ticketmate/backend/common/infrastructure/converter/NullIfBlankConverter.java
@@ -1,0 +1,18 @@
+package com.ticketmate.backend.common.infrastructure.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = false)
+public class NullIfBlankConverter implements AttributeConverter<String, String> {
+
+  @Override
+  public String convertToDatabaseColumn(String s) {
+    return (s != null && s.isBlank()) ? null : s;
+  }
+
+  @Override
+  public String convertToEntityAttribute(String s) {
+    return "";
+  }
+}

--- a/ticketmate-concerthall/src/main/java/com/ticketmate/backend/concerthall/infrastructure/entity/ConcertHall.java
+++ b/ticketmate-concerthall/src/main/java/com/ticketmate/backend/concerthall/infrastructure/entity/ConcertHall.java
@@ -1,8 +1,10 @@
 package com.ticketmate.backend.concerthall.infrastructure.entity;
 
+import com.ticketmate.backend.common.infrastructure.converter.NullIfBlankConverter;
 import com.ticketmate.backend.common.infrastructure.persistence.BasePostgresEntity;
 import com.ticketmate.backend.concerthall.core.constant.City;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -37,5 +39,6 @@ public class ConcertHall extends BasePostgresEntity {
   private City city; // 지역
 
   @Column(unique = true)
+  @Convert(converter = NullIfBlankConverter.class)
   private String webSiteUrl; // 사이트 URL
 }


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 공연장 정보의 웹사이트 URL을 빈 값으로 입력했을 때 발생하던 저장/조회 불일치 문제를 해소했습니다. 이제 빈 값은 안전하게 처리되어 화면에 표시되지 않습니다.
  - 공백만 포함된 URL이 잘못 저장되던 현상을 방지해 잘못된 링크 노출 가능성을 줄였습니다.
  - 입력 폼과 상세 화면 간 표시 규칙을 통일해 데이터 일관성과 사용자 경험을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->